### PR TITLE
Correct vinput path for local share

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ vinput model add <model-name>   # Download and install
 vinput model use <model-name>   # Set as active model
 ```
 
-Or manually place a model directory in `~/.local/share/fcitx5-vinput/models/<model-name>/` containing:
+Or manually place a model directory in `~/.local/share/vinput/models/<model-name>/` containing:
 - `vinput-model.json`
 - `model.int8.onnx` or `model.onnx`
 - `tokens.txt`

--- a/README_zh.md
+++ b/README_zh.md
@@ -79,7 +79,7 @@ vinput model add <模型名>        # 下载并安装
 vinput model use <模型名>        # 设置为当前模型
 ```
 
-也可手动将模型目录放到 `~/.local/share/fcitx5-vinput/models/<模型名>/`，目录内需包含：
+也可手动将模型目录放到 `~/.local/share/vinput/models/<模型名>/`，目录内需包含：
 - `vinput-model.json`
 - `model.int8.onnx` 或 `model.onnx`
 - `tokens.txt`


### PR DESCRIPTION
Correct `~/.local/share/fcitx5-vinput/models/<model-name>/` to `~/.local/share/vinput/models/<model-name>/`