### PR TITLE
Better error logs

### DIFF
--- a/src/cli/systemd_client.cpp
+++ b/src/cli/systemd_client.cpp
@@ -32,6 +32,15 @@ int SystemctlRestart() {
 
 int JournalctlLogs(bool follow, int lines) {
     std::string lines_str = std::to_string(lines);
+    // use --grep vinput to filter logs
+    // workaround for https://github.com/flatpak/flatpak/issues/5870
+    if (vinput::path::isInsideFlatpak()) {
+        if (follow) {
+            return RunCommand({"journalctl", "--user", "-t", "flatpak", "--grep", "vinput", "-n", lines_str.c_str(), "-f", nullptr});
+        }
+        return RunCommand({"journalctl", "--user", "-t", "flatpak", "--grep", "vinput", "-n", lines_str.c_str(), nullptr});
+    }
+
     if (follow) {
         return RunCommand({"journalctl", "--user-unit", kServiceUnit,
                            "-n", lines_str.c_str(), "-f", nullptr});

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -31,10 +31,12 @@
 #include <QApplication>
 #include <QEventLoop>
 #include <QPalette>
+#include <QSettings>
 #include <algorithm>
 
 #include "common/asr_defaults.h"
 #include "common/llm_defaults.h"
+#include "common/path_utils.h"
 
 namespace {
 
@@ -432,13 +434,21 @@ bool RunVinputJson(const QStringList &args, QJsonDocument *out_doc,
     return false;
   }
 
+  QByteArray output = proc.readAllStandardOutput();
+
   if (proc.exitStatus() != QProcess::NormalExit || proc.exitCode() != 0) {
+    // not only stderr, but also try to parse stdout
+    if (out_doc && !output.isEmpty()) {
+      QJsonParseError pe;
+      QJsonDocument data = QJsonDocument::fromJson(output, &pe);
+      if (pe.error == QJsonParseError::NoError)
+        *out_doc = data;
+    }
     if (error_out)
       *error_out = QString::fromUtf8(proc.readAllStandardError()).trimmed();
     return false;
   }
 
-  QByteArray output = proc.readAllStandardOutput();
   QJsonParseError parse_error;
   QJsonDocument doc = QJsonDocument::fromJson(output, &parse_error);
   if (parse_error.error != QJsonParseError::NoError) {
@@ -1785,6 +1795,11 @@ void MainWindow::refreshDaemonStatus() {
   QString err;
   bool ok = RunVinputJson({"status"}, &doc, &err);
 
+  // if daemon is not running, vinput status return code may not be 0
+  // but we can still show "Stopped" instead of "Error:"
+  if (!ok && doc.isObject())
+    ok = true;
+
   if (!ok || !doc.isObject()) {
     lblDaemonStatus->setText(tr("Error: %1").arg(err));
     lblDaemonStatus->setStyleSheet("color: red;");
@@ -1825,6 +1840,26 @@ void MainWindow::onDaemonStart() {
   btnDaemonStart->setEnabled(false);
   QProcess::startDetached("vinput", QStringList() << "daemon" << "start");
   // The timer will catch the state change shortly.
+
+  // Try to show a message box with error logs
+  QTimer::singleShot(1500, this, [this]() {
+    QJsonDocument doc;
+    QString err;
+    RunVinputJson({"status"}, &doc, &err);
+    if (doc.isObject() && !doc.object().value("running").toBool()) {
+      // daemon start failed, try to get logs
+      QProcess logProc;
+      logProc.start("vinput", QStringList() << "daemon" << "logs" << "-n" << "5");
+      logProc.waitForFinished(3000);
+      QString logs = QString::fromUtf8(logProc.readAllStandardOutput() +
+                                       logProc.readAllStandardError()).trimmed();
+      if (!logs.isEmpty()) {
+        QMessageBox::warning(this, tr("Error"),
+                             logs);
+      }
+    }
+    refreshDaemonStatus();
+  });
 }
 
 void MainWindow::onDaemonStop() {


### PR DESCRIPTION
Depends on #16 

## Description

当前，在没有装 model 的时候，daemon 是无法启动的，GUI 会静默报错，需要用户自己看 logs 发现原因
这个 pr 在启动 daemon 之后获取最新的几条 daemon logs，像这样：
<img width="1066" height="841" alt="image" src="https://github.com/user-attachments/assets/4b27929a-3517-413d-b4f8-1c8b9ea7ccd4" />
