### PR TITLE
fix(nix): build vosk deps from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ sudo apt-get install -f
 { pkgs, ... }@inputs:
 let
   fcitx5-vinput = inputs.fcitx5-vinput.packages."${pkgs.stdenv.hostPlatform.system}".default;
+  # Use the Vosk-enabled build instead if you need Vosk support:
+  # fcitx5-vinput = inputs.fcitx5-vinput.packages."${pkgs.stdenv.hostPlatform.system}".fcitx5-vinput-vosk;
 in
 {
   home.packages = [

--- a/README_zh.md
+++ b/README_zh.md
@@ -114,6 +114,8 @@ sudo apt-get install -f
 { pkgs, ... }@inputs:
 let
   fcitx5-vinput = inputs.fcitx5-vinput.packages."${pkgs.stdenv.hostPlatform.system}".default;
+  # 如果需要 Vosk 功能，请改用 Vosk 版本：
+  # fcitx5-vinput = inputs.fcitx5-vinput.packages."${pkgs.stdenv.hostPlatform.system}".fcitx5-vinput-vosk;
 in
 {
   home.packages = [

--- a/flake.nix
+++ b/flake.nix
@@ -35,76 +35,148 @@
           pkgs = pkgsFor system;
           sherpa-deps = sherpa-onnx.packages."${pkgs.stdenv.hostPlatform.system}";
 
+          openfst-vosk-src = pkgs.fetchFromGitHub {
+            owner = "alphacep";
+            repo = "openfst";
+            rev = "18e94e63870ebcf79ebb42b7035cd3cb626ec090";
+            sha256 = "sha256-059BDNHbnim/rIMAaJ/+mD698R6chCdddOYVEtaYgfc=";
+          };
+
+          kaldi-vosk = pkgs.kaldi.overrideAttrs (old: {
+            version = "0.3.50-vosk";
+            src = pkgs.fetchFromGitHub {
+              owner = "alphacep";
+              repo = "kaldi";
+              rev = "bc5baf14231660bd50b7d05788865b4ac6c34481";
+              sha256 = "sha256-nFIKzBRZ6Og0Oj1wuYRMN33e1uZli5OLZSdnjUIybfg=";
+            };
+            nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+              pkgs.clang
+              pkgs.mold
+            ];
+            cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+              "-DFETCHCONTENT_SOURCE_DIR_OPENFST:PATH=${openfst-vosk-src}"
+              "-DCMAKE_C_FLAGS=-I${openfst-vosk-src}/src/include"
+              "-DCMAKE_CXX_FLAGS=-I${openfst-vosk-src}/src/include"
+              "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold"
+              "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold"
+              "-DCMAKE_C_COMPILER=clang"
+              "-DCMAKE_CXX_COMPILER=clang++"
+            ];
+            patches = (old.patches or [ ]) ++ [
+              ./patches/kaldi-openfst-ngram.patch
+            ];
+
+            postPatch = (old.postPatch or "") + ''
+              substituteInPlace CMakeLists.txt \
+                --replace "@OPENFST_ROOT@" "${openfst-vosk-src}"
+            '';
+          });
+
           vosk = pkgs.stdenv.mkDerivation {
             pname = "vosk-api";
             version = "0.3.50";
             src = pkgs.fetchurl {
-              url = "https://archive.archlinux.org/packages/v/vosk-api/vosk-api-0.3.50-7-x86_64.pkg.tar.zst";
-              sha256 = "80aae4295523c3849fd6f290882085976305ec8a3ad55a1a8211c4896b7a08b7";
+              url = "https://github.com/alphacep/vosk-api/archive/refs/tags/v0.3.50.tar.gz";
+              sha256 = "03zp4h8a94q2wb76bjgp8ji6nqxcyb55fhldygss5jcrqny6f46c";
             };
-            nativeBuildInputs = [ pkgs.zstd ];
-            unpackPhase = ''
-              mkdir -p src
-              tar -xf $src -C src
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pkgs.clang
+              pkgs.mold
+            ];
+
+            buildInputs = [
+              kaldi-vosk
+            ];
+
+            dontConfigure = true;
+
+            buildPhase = ''
+              runHook preBuild
+              cd src
+              make -j$NIX_BUILD_CORES \
+                KALDI_ROOT=${kaldi-vosk} \
+                OPENFST_ROOT=${kaldi-vosk} \
+                USE_SHARED=1 \
+                HAVE_OPENBLAS_CLAPACK=0 \
+                CXX=clang++ \
+                EXTRA_CFLAGS="-I${kaldi-vosk}/include/kaldi -I${kaldi-vosk}/include/openfst" \
+                EXTRA_LDFLAGS="-L${kaldi-vosk}/lib -Wl,-rpath,${kaldi-vosk}/lib -fuse-ld=mold"
+              runHook postBuild
             '';
+
             installPhase = ''
               install -d $out/lib $out/include
-              install -m 755 src/usr/lib/libvosk.so $out/lib/
-              install -m 644 src/usr/include/vosk_api.h $out/include/
+              install -m 755 libvosk.so $out/lib/
+              install -m 644 vosk_api.h $out/include/
             '';
-            dontFixup = true;
-            meta.platforms = [ "x86_64-linux" ];
+
+            meta.platforms = [
+              "x86_64-linux"
+              "aarch64-linux"
+            ];
           };
 
-          fcitx5-vinput = pkgs.stdenv.mkDerivation {
-            pname = "fcitx5-vinput";
-            inherit version;
-            src = self;
+          mkFcitx5Vinput =
+            {
+              withVosk ? true,
+            }:
+            pkgs.stdenv.mkDerivation {
+              pname = "fcitx5-vinput";
+              inherit version;
+              src = self;
 
-            nativeBuildInputs = with pkgs; [
-              cmake
-              pkg-config
-              gettext
-              fcitx5
-              qt6.wrapQtAppsHook
-              autoPatchelfHook
-            ];
+              nativeBuildInputs = with pkgs; [
+                cmake
+                pkg-config
+                gettext
+                fcitx5
+                qt6.wrapQtAppsHook
+                autoPatchelfHook
+              ];
 
-            buildInputs = with pkgs; [
-              fcitx5
-              systemdLibs
-              curl
-              libarchive
-              openssl
-              pipewire
-              onnxruntime
-              qt6.qtbase
-              cli11
-              sherpa-deps.sherpa-onnx
-              sherpa-deps.nlohmann_json
-              clang
-              mold
-            ] ++ pkgs.lib.optionals (system == "x86_64-linux") [ vosk ];
+              buildInputs =
+                with pkgs;
+                [
+                  fcitx5
+                  systemdLibs
+                  curl
+                  libarchive
+                  openssl
+                  pipewire
+                  onnxruntime
+                  qt6.qtbase
+                  cli11
+                  sherpa-deps.sherpa-onnx
+                  nlohmann_json
+                  clang
+                  mold
+                ]
+                ++ pkgs.lib.optionals withVosk [ vosk ];
 
-            cmakeFlags = [
-              "-DVINPUT_FETCH_CLI11=OFF"
-              "-DCMAKE_BUILD_TYPE=Release"
-              "-DCMAKE_C_COMPILER=clang"
-              "-DCMAKE_CXX_COMPILER=clang++"
-              "-DCMAKE_LINKER=mold"
-              "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold"
-              "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold"
+              cmakeFlags = [
+                "-DVINPUT_FETCH_CLI11=OFF"
+                "-DCMAKE_BUILD_TYPE=Release"
+                "-DCMAKE_C_COMPILER=clang"
+                "-DCMAKE_CXX_COMPILER=clang++"
+                "-DCMAKE_LINKER=mold"
+                "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold"
+                "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold"
 
-            ];
+              ];
 
-            postInstall = ''
-              rm -f $out/lib/fcitx5-vinput/libonnxruntime.so
-            '';
-          };
+              postInstall = ''
+                rm -f $out/lib/fcitx5-vinput/libonnxruntime.so
+              '';
+            };
         in
         {
-          inherit fcitx5-vinput vosk;
-          default = fcitx5-vinput;
+          fcitx5-vinput = mkFcitx5Vinput { withVosk = false; };
+          fcitx5-vinput-vosk = mkFcitx5Vinput { withVosk = true; };
+          inherit vosk kaldi-vosk;
+          default = mkFcitx5Vinput { withVosk = false; };
         }
       );
       devShells = forAllSystems (
@@ -115,6 +187,29 @@
         in
         {
           default = pkgs.mkShell {
+            packages =
+              with pkgs;
+              [
+                cmake
+                fcitx5
+                pkg-config
+                gettext
+                systemdLibs
+                curl
+                libarchive
+                openssl
+                onnxruntime
+                pipewire
+                qt6.qtbase
+                qt6.wrapQtAppsHook
+                cli11
+                sherpa-deps.sherpa-onnx
+                nlohmann_json
+              ]
+              ++ pkgs.lib.optionals true [ self.packages.${system}.vosk ];
+          };
+
+          no-vosk = pkgs.mkShell {
             packages = with pkgs; [
               cmake
               fcitx5
@@ -130,8 +225,8 @@
               qt6.wrapQtAppsHook
               cli11
               sherpa-deps.sherpa-onnx
-              sherpa-deps.nlohmann_json
-            ] ++ pkgs.lib.optionals (system == "x86_64-linux") [ self.packages.${system}.vosk ];
+              nlohmann_json
+            ];
           };
         }
       );

--- a/patches/kaldi-openfst-ngram.patch
+++ b/patches/kaldi-openfst-ngram.patch
@@ -1,0 +1,33 @@
+--- /nix/store/14mp08xwd123cc2mqfpz36wj3qm529hb-source/CMakeLists.txt	1970-01-01 08:00:01.000000000 +0800
++++ src/CMakeLists.txt	2026-04-04 10:01:20.161537340 +0700
+@@ -221,6 +221,8 @@
+ #            NAMES fst
+ #            PATHS ${CMAKE_CURRENT_SOURCE_DIR}/tools/openfst/lib
+ #            REQUIRED)
++set(OPENFST_ROOT_DIR @OPENFST_ROOT@)
++include(third_party/openfst_lib_target)
+ #find_path(OpenFST_INCLUDE_DIR
+ #            NAMES "fst/fst.h"
+ #            PATHS "${CMAKE_CURRENT_SOURCE_DIR}/tools/openfst/include"
+--- /nix/store/14mp08xwd123cc2mqfpz36wj3qm529hb-source/cmake/third_party/openfst_lib_target.cmake	1970-01-01 08:00:01.000000000 +0800
++++ src/cmake/third_party/openfst_lib_target.cmake	2026-04-04 10:01:20.164537429 +0700
+@@ -29,3 +29,19 @@
+ unset(fst_source_dir)
+ unset(fst_include_dir)
+ unset(fst_sources)
++
++# Build ngram extension library (needed by Vosk).
++set(fst_ngram_source_dir ${OPENFST_ROOT_DIR}/src/extensions/ngram)
++file(GLOB fst_ngram_sources "${fst_ngram_source_dir}/*.cc")
++add_library(fstngram ${fst_ngram_sources})
++add_dependencies(fstngram fst)
++target_include_directories(fstngram PUBLIC
++     $<BUILD_INTERFACE:${OPENFST_ROOT_DIR}/src/include>
++     $<INSTALL_INTERFACE:include/openfst>
++)
++install(TARGETS fstngram
++    EXPORT kaldi-targets
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++)


### PR DESCRIPTION
* build from source to align with the current libc deps in nix system instead of using prebuilt libs
* add `fcitx5-vinput-vosk` 
* default to non-vosk version