### PR TITLE
fix: prevent Fcitx5 crash by delaying DBus slot destruction in async callbacks

### DIFF
--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -341,7 +341,7 @@ bool VinputEngine::callStartRecording() {
   pending_start_call_slot_ = msg.callAsync(
       vinput::runtime::kDbusCallTimeoutUsec,
       [this](fcitx::dbus::Message &reply) {
-        pending_start_call_slot_.reset();
+        auto slot = std::move(pending_start_call_slot_);
         if (!reply || reply.isError()) {
           noteDaemonSyncFailure();
           fprintf(stderr, "vinput: StartRecording rejected by daemon\n");
@@ -377,7 +377,7 @@ bool VinputEngine::callStartCommandRecording(const std::string &selected_text) {
   pending_start_call_slot_ = msg.callAsync(
       vinput::runtime::kDbusCallTimeoutUsec,
       [this](fcitx::dbus::Message &reply) {
-        pending_start_call_slot_.reset();
+        auto slot = std::move(pending_start_call_slot_);
         if (!reply || reply.isError()) {
           noteDaemonSyncFailure();
           fprintf(stderr, "vinput: StartCommandRecording rejected by daemon\n");
@@ -413,7 +413,7 @@ bool VinputEngine::callStopRecording(const std::string &scene_id) {
   pending_stop_call_slot_ = msg.callAsync(
       vinput::runtime::kDbusCallTimeoutUsec,
       [this](fcitx::dbus::Message &reply) {
-        pending_stop_call_slot_.reset();
+        auto slot = std::move(pending_stop_call_slot_);
         if (!reply || reply.isError()) {
           noteDaemonSyncFailure();
           fprintf(stderr, "vinput: StopRecording rejected by daemon\n");


### PR DESCRIPTION
### What does this PR do?
Fixes a critical Use-After-Free bug that causes Fcitx5 to crash with a Segmentation Fault when `vinput-daemon` rejects a Start/Stop recording request (e.g., when the user presses the trigger key while the daemon is already busy).

### Root Cause & Fix
In `src/addon/dbus/vinput_dbus.cpp`, `pending_start_call_slot_.reset()` and `pending_stop_call_slot_.reset()` were called at the very beginning of their respective async callback lambdas. 

Destroying a `fcitx::dbus::Slot` from within its own executing callback leads to memory corruption when the Fcitx5 event loop cleans up. 

This PR fixes the issue by using `auto slot = std::move(...)` to safely transfer ownership and delay the destruction of the slot until the lambda scope ends.

### Changes made
- `callStartRecording`: Delayed `pending_start_call_slot_` destruction.
- `callStartCommandRecording`: Delayed `pending_start_call_slot_` destruction.
- `callStopRecording`: Delayed `pending_stop_call_slot_` destruction.