### PR TITLE
asr: validate moonshine local models and document offline-only support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 
 include(GNUInstallDirs)
 
+option(VINPUT_BUILD_TESTS "Build fcitx5-vinput unit tests" OFF)
+
 set(VINPUT_PACKAGE_RELEASE "1"
     CACHE STRING "Package release revision for distro packages")
 set(VINPUT_PACKAGE_CONTACT "fcitx5-vinput maintainers <noreply@github.com>"
@@ -90,6 +92,11 @@ add_subdirectory(src/addon)
 add_subdirectory(src/cli)
 add_subdirectory(src/gui)
 add_subdirectory(po)
+
+if(VINPUT_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
 string(REPLACE "-" "~" VINPUT_DEBIAN_UPSTREAM_VERSION "${PROJECT_VERSION}")
 

--- a/README.md
+++ b/README.md
@@ -1,151 +1,38 @@
-<div align="center">
-
 # fcitx5-vinput
 
-**Voice input for Fcitx5 — local and cloud ASR, LLM rewriting, cross-distro packages**
+A simpler Moonshine-focused fork of `fcitx5-vinput`.
 
-[![License](https://img.shields.io/github/license/xifan2333/fcitx5-vinput)](LICENSE)
-[![CI](https://github.com/xifan2333/fcitx5-vinput/actions/workflows/release.yml/badge.svg)](https://github.com/xifan2333/fcitx5-vinput/actions/workflows/release.yml)
-[![Release](https://img.shields.io/github/v/release/xifan2333/fcitx5-vinput)](https://github.com/xifan2333/fcitx5-vinput/releases)
-[![AUR](https://img.shields.io/aur/version/fcitx5-vinput-bin)](https://aur.archlinux.org/packages/fcitx5-vinput-bin)
-[![Downloads](https://img.shields.io/github/downloads/xifan2333/fcitx5-vinput/total)](https://github.com/xifan2333/fcitx5-vinput/releases)
+## What is different in this version
 
-[English](README.md) | [中文](README_zh.md) | [Documentation](https://xifan2333.github.io/fcitx5-vinput/)
+This fork is focused on getting Moonshine local ASR working cleanly and making that path easier to understand and review.
 
-https://github.com/user-attachments/assets/5a548a68-153c-4842-bab6-926f30bb720e
+Changes in this fork:
+- adds Moonshine local model validation
+- adds a clear offline-only error for Moonshine on the streaming backend
+- documents the expected Moonshine `vinput-model.json` layout
+- adds a small regression test for Moonshine model validation
 
-</div>
+## What this fork is trying to do
 
-## Features
+The upstream project supports a broader set of providers, models, and workflows.
+This version keeps the focus on a compact Moonshine path for local Linux voice input.
 
-- **Two trigger modes** — tap to toggle recording, or hold to push-to-talk
-- **Local & cloud ASR** — offline [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) models or cloud providers (Doubao, Aliyun Bailian, ElevenLabs, OpenAI-compatible), switchable at runtime with `F8`
-- **LLM post-processing** — error correction, formatting, translation via scenes
-- **Command mode** — select text, speak an instruction, release to apply
-- **GUI & CLI** — `vinput-gui` for quick setup, `vinput` CLI for full control
-- **Cross-distro** — Arch, Fedora, Ubuntu/Debian, Nix, Flatpak
+## Current status
 
-## Installation
+- builds successfully
+- Moonshine local models can be discovered and activated
+- the daemon initializes Moonshine offline ASR correctly
+- speech-to-text works end to end with a local Moonshine model
 
-### Arch Linux (AUR)
+## Upstream and fork
 
-```bash
-yay -S fcitx5-vinput-bin
-```
+Upstream project:
+- `xifan2333/fcitx5-vinput`
 
-### Fedora (COPR)
+This fork:
+- `Hieraphant/fcitx5-vinput`
 
-```bash
-sudo dnf copr enable xifan/fcitx5-vinput-bin
-sudo dnf install fcitx5-vinput
-```
+## Notes
 
-### Ubuntu 24.04 (PPA)
-
-```bash
-sudo add-apt-repository ppa:xifan233/ppa
-sudo apt update
-sudo apt install fcitx5-vinput
-```
-
-### Ubuntu / Debian (manual)
-
-```bash
-# Download latest .deb from GitHub Releases
-sudo dpkg -i fcitx5-vinput_*.deb
-sudo apt-get install -f
-```
-
-### Nix (flake)
-
-Supports `x86_64-linux` and `aarch64-linux`.
-
-```nix
-inputs.fcitx5-vinput.url = "github:xifan2333/fcitx5-vinput";
-```
-
-Binary cache via [Cachix](https://fcitx5-vinput.cachix.org):
-
-```nix
-nixConfig = {
-  extra-substituters = [ "https://fcitx5-vinput.cachix.org" ];
-  extra-trusted-public-keys = [ "fcitx5-vinput.cachix.org-1:XpX3AA6+dDIX4qJhb1QM7sbTwX6/qSlGvW8Z5NK6XdU=" ];
-};
-```
-
-Full Home Manager example in the [install docs](https://xifan2333.github.io/fcitx5-vinput/install/).
-
-### Flatpak
-
-```bash
-flatpak remote-add --if-not-exists xifan https://xifan2333.github.io/flatpak-auto/xifan.flatpakrepo
-flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.flatpakref
-```
-
-After installation, grant the extra permissions and restart Fcitx5:
-
-```bash
-flatpak override --user --filesystem=xdg-run/pipewire-0 org.fcitx.Fcitx5
-flatpak override --user --filesystem=xdg-config/systemd:create org.fcitx.Fcitx5
-flatpak override --user --filesystem=xdg-cache org.fcitx.Fcitx5
-flatpak kill org.fcitx.Fcitx5
-
-Download the package for your system from [GitHub Releases](https://github.com/xifan2333/fcitx5-vinput/releases/latest):
-
-- **Debian / Linux Mint / Ubuntu (other)**: `.deb`
-- **openSUSE / Fedora (other)**: `.rpm`
-- **Arch-based**: `.pkg.tar.zst`
-- **Flatpak**: `.flatpak`
-- **Generic Linux**: `_bundled.tar.gz`
-
-### Build from source
-
-**Dependencies:** cmake, fcitx5, pipewire, libcurl, nlohmann-json, CLI11, Qt6
-
-```bash
-sudo bash scripts/build-sherpa-onnx.sh
-cmake --preset release-clang-mold
-cmake --build --preset release-clang-mold
-sudo cmake --install build
-```
-
-## Quick start
-
-```bash
-systemctl --user enable --now vinput-daemon.service
-fcitx5 -r
-```
-
-Open **Vinput GUI** → **Resources → Models** → download and activate a model. Then:
-
-- **Tap** `Alt_R` — start/stop recording
-- **Hold** `Alt_R` — push-to-talk
-
-## Key bindings
-
-| Key | Default | Function |
-|-----|---------|----------|
-| Trigger Key | `Alt_R` | Tap to toggle recording; hold to push-to-talk |
-| Command Key | `Control_R` | Hold after selecting text to modify with voice |
-| ASR Menu Key | `F8` | Open ASR provider / model switcher |
-| Scene Menu Key | `Shift_R` | Open scene switcher |
-
-All keys can be customized in Fcitx5 configuration.
-
-## Documentation
-
-For ASR configuration, scenes & LLM setup, CLI reference, and registry contribution guide, see the [documentation site](https://xifan2333.github.io/fcitx5-vinput/).
-
-## License
-
-[GPL-3.0](LICENSE)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=xifan2333/fcitx5-vinput&type=Date)](https://star-history.com/#xifan2333/fcitx5-vinput&Date)
-
-## Sponsor
-
-If this project has been helpful to you, feel free to support it.
-
-<img src="https://raw.githubusercontent.com/xifan2333/xifan2333/main/assets/donate.png" alt="Donate" width="300" />
+This repo is intended to keep the Moonshine-related changes easier to follow.
+The separate registry follow-up can be done after the main runtime patch.

--- a/site/src/content/docs/asr/index.md
+++ b/site/src/content/docs/asr/index.md
@@ -60,6 +60,53 @@ vinput model remove <name>      # Uninstall
 vinput model info <name>        # View details
 ```
 
+### Moonshine
+
+Moonshine uses the existing `sherpa-offline` local ASR path. There is no
+separate daemon backend or GUI code path for it inside Vinput. Once a
+Moonshine package is installed with a valid `vinput-model.json`, it behaves
+like any other local model in **Resources → Models** and in the `vinput model`
+CLI.
+
+For Moonshine, `vinput-model.json` should use:
+
+- `backend: "sherpa-offline"`
+- `runtime: "offline"`
+- `family: "moonshine"`
+- `model.tokens`
+- `model.moonshine.preprocessor`
+- `model.moonshine.encoder`
+- `model.moonshine.uncached_decoder`
+- `model.moonshine.cached_decoder`
+
+`model.moonshine.merged_decoder` is optional.
+
+Example:
+
+```json
+{
+  "backend": "sherpa-offline",
+  "runtime": "offline",
+  "family": "moonshine",
+  "language": "en",
+  "model": {
+    "tokens": "tokens.txt",
+    "provider": "cpu",
+    "num_threads": 2,
+    "moonshine": {
+      "preprocessor": "preprocess.onnx",
+      "encoder": "encode.int8.onnx",
+      "uncached_decoder": "uncached_decode.int8.onnx",
+      "cached_decoder": "cached_decode.int8.onnx"
+    }
+  }
+}
+```
+
+Moonshine is currently offline-only in Vinput. Selecting a Moonshine package
+for the streaming sherpa backend will fail with a clear error instead of
+falling through as an unknown model family.
+
 ## Cloud providers
 
 ### Concept

--- a/site/src/content/docs/registry/index.md
+++ b/site/src/content/docs/registry/index.md
@@ -220,7 +220,7 @@ Model entries in `models.json` describe downloadable sherpa-onnx model archives.
 |-------|-------------|
 | `backend` | `sherpa-offline` or `sherpa-streaming` |
 | `runtime` | `offline` or `online` |
-| `family` | sherpa-onnx C API family: `dolphin`, `sense_voice`, `paraformer`, `transducer`, `qwen3_asr` |
+| `family` | sherpa-onnx C API family: `dolphin`, `sense_voice`, `paraformer`, `transducer`, `moonshine`, `qwen3_asr` |
 | `language` | Language code |
 | `size_bytes` | Model size |
 | `supports_hotwords` | Whether hotword boosting is supported |
@@ -228,6 +228,48 @@ Model entries in `models.json` describe downloadable sherpa-onnx model archives.
 | `model` | sherpa-onnx model config (tokens file, family-specific model paths) |
 
 Field naming follows sherpa-onnx C API conventions.
+
+### Moonshine local model notes
+
+Moonshine local ASR models do not require a special app-side provider. In the
+main `fcitx5-vinput` repo, Moonshine already runs through the existing offline
+sherpa backend selected by `family: "moonshine"`.
+
+For registry maintainers, the important part is the `vinput_model` payload that
+gets written into `vinput-model.json` during install. That payload should use:
+
+- `backend: "sherpa-offline"`
+- `runtime: "offline"`
+- `family: "moonshine"`
+- `model.tokens`
+- `model.moonshine.preprocessor`
+- `model.moonshine.encoder`
+- `model.moonshine.uncached_decoder`
+- `model.moonshine.cached_decoder`
+
+`model.moonshine.merged_decoder` may be included when the packaged model has
+it, but it is not required by Vinput.
+
+Minimal `vinput_model` example:
+
+```json
+{
+  "backend": "sherpa-offline",
+  "runtime": "offline",
+  "family": "moonshine",
+  "language": "en",
+  "model": {
+    "tokens": "tokens.txt",
+    "provider": "cpu",
+    "moonshine": {
+      "preprocessor": "preprocess.onnx",
+      "encoder": "encode.int8.onnx",
+      "uncached_decoder": "uncached_decode.int8.onnx",
+      "cached_decoder": "cached_decode.int8.onnx"
+    }
+  }
+}
+```
 
 ## Contributing a resource
 

--- a/src/common/asr/model_manager.cpp
+++ b/src/common/asr/model_manager.cpp
@@ -267,6 +267,44 @@ bool HasTokenizer(const ModelInfo &info) {
   return !info.File("tokenizer").empty() && fs::exists(info.File("tokenizer"));
 }
 
+bool HasRequiredMoonshineFiles(const ModelInfo &info,
+                               std::vector<std::string> *missing_keys = nullptr) {
+  if (info.family != "moonshine") {
+    return true;
+  }
+
+  static constexpr const char *kMoonshineRequiredKeys[] = {
+      "preprocessor",
+      "encoder",
+      "uncached_decoder",
+      "cached_decoder",
+  };
+
+  bool ok = true;
+  for (const char *key : kMoonshineRequiredKeys) {
+    const auto path = info.File(key);
+    if (path.empty() || !fs::exists(path)) {
+      ok = false;
+      if (missing_keys) {
+        missing_keys->emplace_back(key);
+      }
+    }
+  }
+
+  return ok;
+}
+
+std::string JoinFieldNames(const std::vector<std::string> &fields) {
+  std::string joined;
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (i > 0) {
+      joined += ", ";
+    }
+    joined += fields[i];
+  }
+  return joined;
+}
+
 bool HasRequiredTextAsset(const ModelInfo &info) {
   return FamilyUsesTokenizerAsset(info.family) ? HasTokenizer(info)
                                                : HasTokens(info);
@@ -426,6 +464,15 @@ bool ModelManager::EnsureModels(std::string *error) {
     if (error) {
       *error = RequiredTextAssetPathKey(info) +
                " file not found for model '" + model_id_ + "'";
+    }
+    return false;
+  }
+
+  std::vector<std::string> missing_moonshine_files;
+  if (!HasRequiredMoonshineFiles(info, &missing_moonshine_files)) {
+    if (error) {
+      *error = "missing required Moonshine files for model '" + model_id_ +
+               "': " + JoinFieldNames(missing_moonshine_files);
     }
     return false;
   }
@@ -598,6 +645,15 @@ bool ModelManager::Validate(const std::string &model_id,
             RequiredTextAssetField(info);
     } else {
       if (error) *error = path_key + " file not found: " + asset_path;
+    }
+    return false;
+  }
+
+  std::vector<std::string> missing_moonshine_files;
+  if (!HasRequiredMoonshineFiles(info, &missing_moonshine_files)) {
+    if (error) {
+      *error = "vinput-model.json is missing required Moonshine files: " +
+               JoinFieldNames(missing_moonshine_files);
     }
     return false;
   }

--- a/src/daemon/asr/backends/sherpa_streaming_backend.cpp
+++ b/src/daemon/asr/backends/sherpa_streaming_backend.cpp
@@ -418,6 +418,12 @@ private:
       config.model_config.nemo_ctc.model = f_model.c_str();
     } else if (model_info_.family == "t_one_ctc") {
       config.model_config.t_one_ctc.model = f_model.c_str();
+    } else if (model_info_.family == "moonshine") {
+      if (error) {
+        *error =
+            "Moonshine models are currently supported only by sherpa-offline";
+      }
+      return false;
     } else {
       if (error) {
         *error = "Unsupported sherpa-streaming model family '" +

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(vinput-model-manager-moonshine-test
+    model_manager_moonshine_test.cpp
+)
+
+target_include_directories(vinput-model-manager-moonshine-test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(vinput-model-manager-moonshine-test PRIVATE
+    vinput-common
+)
+
+add_test(NAME model_manager_moonshine
+    COMMAND vinput-model-manager-moonshine-test
+)

--- a/tests/model_manager_moonshine_test.cpp
+++ b/tests/model_manager_moonshine_test.cpp
@@ -1,0 +1,135 @@
+#include "common/asr/model_manager.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string UniqueSuffix() {
+  return std::to_string(static_cast<unsigned long long>(std::rand()));
+}
+
+fs::path MakeModelDir(const fs::path &base_dir) {
+  return base_dir / "sherpa-onnx" / "moonshine-test";
+}
+
+bool WriteTextFile(const fs::path &path, const std::string &content) {
+  std::ofstream out(path);
+  if (!out.is_open()) {
+    return false;
+  }
+  out << content;
+  return out.good();
+}
+
+bool WriteBinaryPlaceholder(const fs::path &path) {
+  return WriteTextFile(path, "placeholder\n");
+}
+
+bool WriteMoonshineMetadata(const fs::path &model_dir, bool include_cached_decoder) {
+  const char *json_prefix = R"JSON({
+  "backend": "sherpa-offline",
+  "runtime": "offline",
+  "family": "moonshine",
+  "language": "en",
+  "model": {
+    "tokens": "tokens.txt",
+    "moonshine": {
+      "preprocessor": "preprocess.onnx",
+      "encoder": "encode.int8.onnx",
+      "uncached_decoder": "uncached_decode.int8.onnx",
+)JSON";
+
+  const char *json_cached = R"JSON(      "cached_decoder": "cached_decode.int8.onnx"
+    }
+  }
+}
+)JSON";
+
+  const char *json_without_cached = R"JSON(      "cached_decoder": "missing.onnx"
+    }
+  }
+}
+)JSON";
+
+  return WriteTextFile(model_dir / "vinput-model.json",
+                       std::string(json_prefix) +
+                           (include_cached_decoder ? json_cached
+                                                   : json_without_cached));
+}
+
+bool Expect(bool condition, const std::string &message) {
+  if (!condition) {
+    std::cerr << message << std::endl;
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+int main() {
+  const fs::path base_dir =
+      fs::temp_directory_path() / ("vinput-moonshine-test-" + UniqueSuffix());
+  const fs::path model_dir = MakeModelDir(base_dir);
+  std::error_code ec;
+  fs::create_directories(model_dir, ec);
+  if (ec) {
+    std::cerr << "failed to create temp model dir: " << ec.message() << std::endl;
+    return 1;
+  }
+
+  auto cleanup = [&] {
+    std::error_code cleanup_ec;
+    fs::remove_all(base_dir, cleanup_ec);
+  };
+
+  if (!WriteBinaryPlaceholder(model_dir / "tokens.txt") ||
+      !WriteBinaryPlaceholder(model_dir / "preprocess.onnx") ||
+      !WriteBinaryPlaceholder(model_dir / "encode.int8.onnx") ||
+      !WriteBinaryPlaceholder(model_dir / "uncached_decode.int8.onnx") ||
+      !WriteBinaryPlaceholder(model_dir / "cached_decode.int8.onnx") ||
+      !WriteMoonshineMetadata(model_dir, true)) {
+    std::cerr << "failed to stage valid Moonshine model files" << std::endl;
+    cleanup();
+    return 1;
+  }
+
+  const std::string model_id = "model.sherpa-onnx.moonshine-test";
+  ModelManager manager(base_dir.string(), model_id);
+
+  std::string error;
+  if (!Expect(manager.Validate(model_id, &error),
+              "expected valid Moonshine model to validate, got: " + error)) {
+    cleanup();
+    return 1;
+  }
+
+  fs::remove(model_dir / "cached_decode.int8.onnx", ec);
+  if (ec) {
+    std::cerr << "failed to remove cached decoder: " << ec.message() << std::endl;
+    cleanup();
+    return 1;
+  }
+
+  error.clear();
+  if (!Expect(!manager.Validate(model_id, &error),
+              "expected Moonshine validation failure when cached decoder is missing")) {
+    cleanup();
+    return 1;
+  }
+
+  if (!Expect(error.find("cached_decoder") != std::string::npos,
+              "expected cached_decoder in validation error, got: " + error)) {
+    cleanup();
+    return 1;
+  }
+
+  cleanup();
+  return 0;
+}


### PR DESCRIPTION
## Summary

* add Moonshine-specific local model validation
* reject Moonshine under sherpa-streaming with a precise offline-only error
* document Moonshine local-model metadata in ASR and registry docs
* add an opt-in regression test for Moonshine model validation

## Verified

* project builds on Kubuntu 24.04
* Moonshine model is discovered locally
* Moonshine model can be activated with `vinput model use`
* daemon initializes Moonshine successfully
* VAD initializes successfully
* speech-to-text works end to end with the local Moonshine model

## Notes

* remote model catalog does not yet include Moonshine entries
* hotkey behavior on this machine appears press/hold-oriented and is separate from Moonshine runtime support
