### PR TITLE
nix: 为 command provider 补齐 python3 和 libopus 运行时环境

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,10 @@
         system:
         let
           pkgs = pkgsFor system;
+          lib = pkgs.lib;
           sherpa-deps = sherpa-onnx.packages.${system};
+          commandProviderPath = lib.makeBinPath [ pkgs.python3 ];
+          commandProviderLibraryPath = lib.makeLibraryPath [ pkgs.libopus ];
         in
         {
           fcitx5-vinput = pkgs.stdenv.mkDerivation {
@@ -48,6 +51,7 @@
               pkg-config
               gettext
               fcitx5
+              makeBinaryWrapper
               qt6.wrapQtAppsHook
               autoPatchelfHook
             ];
@@ -80,6 +84,12 @@
 
             postInstall = ''
               rm -f $out/lib/fcitx5-vinput/libonnxruntime.so
+
+              for program in $out/bin/*; do
+                wrapProgram "$program" \
+                  --prefix PATH : ${commandProviderPath} \
+                  --prefix LD_LIBRARY_PATH : ${commandProviderLibraryPath}
+              done
             '';
           };
 


### PR DESCRIPTION
## 变更说明
- 为安装后的可执行文件补充 PATH，确保 command ASR provider 可以继承到 python3
- 为安装后的可执行文件补充 LD_LIBRARY_PATH，确保 provider 可以发现 libopus
- 变更范围仅限于 Nix 打包产物的运行时闭包

## 问题背景
在 NixOS 上，文档中约定使用 python3 作为解释器的 command provider 可能会直接启动失败，因为 fcitx5-vinput 打包后的运行环境没有暴露 python3。

在补上 Python 之后，某些通过动态库发现机制加载 Opus 的 provider 仍可能报错，例如 Failed to locate system libopus.，原因是运行环境没有向 provider 暴露 libopus。

## 验证
- nix eval .#packages.x86_64-linux.fcitx5-vinput.pname
- nix build .#fcitx5-vinput --no-link