### PR TITLE
feat(debian): implement automated multi-arch docker build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+build/
+runtime/
+*.deb
+*.tar.bz2
+node_modules/
+.claude/

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,70 @@
+FROM debian:trixie-slim
+
+# 定义代理参数，但不设为全局 ENV，避免影响所有进程
+ARG http_proxy
+ARG https_proxy
+ARG all_proxy
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 1. 将 apt 源替换为国内镜像（清华源），确保 apt 不走代理也很快
+RUN if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+        sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources; \
+    else \
+        sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list; \
+    fi
+
+# 2. 安装依赖（此时强制不使用代理，避免不稳定）
+RUN export http_proxy= https_proxy= all_proxy= && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    debhelper-compat \
+    clang \
+    cmake \
+    mold \
+    ninja-build \
+    pkg-config \
+    gettext \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libarchive-dev \
+    libpipewire-0.3-dev \
+    libsystemd-dev \
+    libfcitx5core-dev \
+    libfcitx5config-dev \
+    libfcitx5utils-dev \
+    fcitx5-modules-dev \
+    libcli11-dev \
+    nlohmann-json3-dev \
+    qt6-base-dev \
+    qt6-tools-dev \
+    qt6-tools-dev-tools \
+    curl \
+    jq \
+    tar \
+    bzip2 \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+
+# 3. 仅在下载 sherpa-onnx (GitHub) 时显式传入代理
+RUN --mount=type=cache,target=/root/.cache/curl \
+    mkdir -p runtime && \
+    http_proxy=$http_proxy https_proxy=$https_proxy all_proxy=$all_proxy \
+    ./scripts/build-sherpa-onnx.sh "" "$(pwd)/runtime"
+
+# 4. 准备 debian 目录并动态生成 changelog
+RUN ln -s packaging/debian debian && \
+    export VERSION=$(cat VERSION) && \
+    printf "fcitx5-vinput ($VERSION) unstable; urgency=low\n\n  * Auto-generated build from VERSION file\n\n -- xifan233 <xifan2333@gmail.com>  $(date -R)\n" > debian/changelog
+
+# 5. 构建 deb 包
+RUN dpkg-buildpackage -b -us -uc
+
+# 6. 专门的导出阶段，只包含 deb 包
+FROM scratch AS exporter
+COPY --from=0 /*.deb /

--- a/justfile
+++ b/justfile
@@ -125,3 +125,26 @@ flatpak-install bundle=flatpak_bundle:
 flatpak-permissions app_id=flatpak_host_app_id:
   flatpak override --user --filesystem=xdg-run/pipewire-0 {{app_id}}
   flatpak override --user --filesystem=xdg-config/systemd:create {{app_id}}
+
+# Build Debian package using Docker
+# Example with proxy (uncomment and adjust as needed):
+# deb:
+#     @DOCKER_BUILDKIT=1 docker build \
+#         --add-host=host.docker.internal:host-gateway \
+#         --build-arg all_proxy=socks5h://host.docker.internal:1080 \
+#         --build-arg http_proxy=http://host.docker.internal:1081 \
+#         --build-arg https_proxy=http://host.docker.internal:1081 \
+#         --target exporter \
+#         -t fcitx5-vinput-builder \
+#         -f Dockerfile.debian \
+#         --output type=local,dest=. .
+deb:
+    @DOCKER_BUILDKIT=1 docker build \
+        --add-host=host.docker.internal:host-gateway \
+        --build-arg all_proxy=${all_proxy:-""} \
+        --build-arg http_proxy=${http_proxy:-""} \
+        --build-arg https_proxy=${https_proxy:-""} \
+        --target exporter \
+        -t fcitx5-vinput-builder \
+        -f Dockerfile.debian \
+        --output type=local,dest=. .

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -27,7 +27,7 @@ Standards-Version: 4.6.2
 Homepage: https://github.com/xifan2333/fcitx5-vinput
 
 Package: fcitx5-vinput
-Architecture: amd64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, fcitx5
 Description: Offline voice input addon for Fcitx5
  Local offline voice input plugin for Fcitx5, powered by sherpa-onnx

--- a/scripts/build-sherpa-onnx.sh
+++ b/scripts/build-sherpa-onnx.sh
@@ -39,6 +39,27 @@ fi
 
 tar -xjf "${archive_path}" -C "${workdir}"
 
+# 修复 aarch64 包缺失头文件的问题
+if [[ "$(uname -m)" == "aarch64" && ! -d "${workdir}/${SHERPA_ONNX_STRIP_DIR}/include" ]]; then
+    echo "aarch64 package missing include directory, fetching headers from x64 package..." >&2
+    # Save current vars
+    main_archive="${SHERPA_ONNX_ARCHIVE}"
+    main_strip_dir="${SHERPA_ONNX_STRIP_DIR}"
+
+    # Get x64 vars
+    sherpa_onnx_set_vars "${version}" "x86_64"
+    x64_archive="${SHERPA_ONNX_ARCHIVE}"
+    x64_url="${SHERPA_ONNX_URL}"
+    x64_strip_dir="${SHERPA_ONNX_STRIP_DIR}"
+
+    curl -fL --retry 3 -o "${workdir}/${x64_archive}" "${x64_url}"
+    tar -xjf "${workdir}/${x64_archive}" -C "${workdir}" "${x64_strip_dir}/include"
+    mv "${workdir}/${x64_strip_dir}/include" "${workdir}/${main_strip_dir}/"
+
+    # Restore main vars (optional but good practice if more steps follow)
+    sherpa_onnx_set_vars "${version}"
+fi
+
 install -d "${prefix}/lib" "${prefix}/include/sherpa-onnx/c-api"
 install -m 755 "${workdir}/${SHERPA_ONNX_STRIP_DIR}/lib/"*.so "${prefix}/lib/"
 install -m 644 "${workdir}/${SHERPA_ONNX_STRIP_DIR}/include/sherpa-onnx/c-api/"*.h "${prefix}/include/sherpa-onnx/c-api/"

--- a/scripts/sherpa-onnx-vars.sh
+++ b/scripts/sherpa-onnx-vars.sh
@@ -4,16 +4,36 @@ SHERPA_ONNX_REPO="k2-fsa/sherpa-onnx"
 
 sherpa_onnx_set_vars() {
     local version="${1:?version is required}"
+    local target_arch="${2:-$(uname -m)}"
+    local arch
+    local suffix="shared-no-tts"
+
+    case "${target_arch}" in
+        x86_64)
+            arch="x64"
+            ;;
+        aarch64)
+            arch="aarch64"
+            suffix="shared-cpu"
+            ;;
+        *)
+            arch="${target_arch}"
+            ;;
+    esac
 
     SHERPA_ONNX_VERSION="${version}"
-    SHERPA_ONNX_ARCHIVE="sherpa-onnx-v${version}-linux-x64-shared-no-tts.tar.bz2"
-    SHERPA_ONNX_STRIP_DIR="sherpa-onnx-v${version}-linux-x64-shared-no-tts"
+    SHERPA_ONNX_ARCHIVE="sherpa-onnx-v${version}-linux-${arch}-${suffix}.tar.bz2"
+    SHERPA_ONNX_STRIP_DIR="sherpa-onnx-v${version}-linux-${arch}-${suffix}"
     SHERPA_ONNX_URL="https://github.com/${SHERPA_ONNX_REPO}/releases/download/v${version}/${SHERPA_ONNX_ARCHIVE}"
     SHERPA_ONNX_SHA256=""
 
     case "${version}" in
         1.12.34)
-            SHERPA_ONNX_SHA256="1c59ff6dcea5f2b56d16273a929b81e383f2b7c636f689a0bdf04a940982512a"
+            if [[ "${target_arch}" == "aarch64" ]]; then
+                SHERPA_ONNX_SHA256="436b207c51c2eb3d281f64d68326123ccfd76062155865c7f328e421ed55b4e1"
+            elif [[ "${target_arch}" == "x86_64" ]]; then
+                SHERPA_ONNX_SHA256="1c59ff6dcea5f2b56d16273a929b81e383f2b7c636f689a0bdf04a940982512a"
+            fi
             ;;
         1.12.31)
             SHERPA_ONNX_SHA256="c60e373867cdb951a7156b046f673cabf1d228c9cee531a848d205cebf63882c"


### PR DESCRIPTION
## Summary
This PR introduces a fully automated, multi-architecture Docker-based workflow for building Debian packages.

### Key Changes:
- **New `Dockerfile.debian`**: Implements a multi-stage build that generates a clean `.deb` package and exports it using BuildKit.
- **Improved `justfile`**: Adds a `just deb` command to handle the entire build process, including proxy support and multi-arch targeting.
- **Dynamic Versioning**: Automatically generates `debian/changelog` from the project's `VERSION` file, removing the need to manually maintain a 
Debian-specific changelog.
- **Multi-Arch Support**: Refactored `sherpa-onnx` scripts to dynamically detect and support both `x86_64` and `aarch64` architectures.
- **Build Efficiency**: Optimized with `.dockerignore`, BuildKit cache mounts for downloads, and automatic mirror switching for faster `apt-get` operations in China.

## Test Plan
1. Ensure Docker with Buildx is installed.
2. Run `just deb`.
3. Verify that a `.deb` package corresponding to your host architecture is generated in the root directory.