### PR TITLE
Support local model display metadata

### DIFF
--- a/src/addon/menu/vinput_menu.cpp
+++ b/src/addon/menu/vinput_menu.cpp
@@ -780,8 +780,12 @@ void VinputEngine::reloadAsrMenuItems() {
       for (const auto &summary : models) {
         const bool item_active =
             (pid == active_provider) && (summary.id == active_model);
-        const std::string model_title = vinput::registry::LookupI18n(
-            i18n_map, summary.id + ".title", summary.id);
+        std::string model_title = summary.title;
+        if (model_title.empty()) {
+          model_title = vinput::registry::LookupI18n(i18n_map,
+                                                     summary.id + ".title",
+                                                     summary.id);
+        }
         std::string label = model_title + " [local]";
         if (have_backend_state && backend_state.reload_in_progress &&
             pid == backend_state.target_provider_id &&

--- a/src/cli/config/asr_actions.cpp
+++ b/src/cli/config/asr_actions.cpp
@@ -540,6 +540,24 @@ int RunAsrConfigListModels(bool available, Formatter &fmt, const CliContext &ctx
   }
 
   const auto models = manager.ListDetailed(activeModel);
+  auto resolve_local_title = [&installed_display_map](const ModelSummary &model) {
+    if (!model.title.empty()) {
+      return model.title;
+    }
+    const auto display_it = installed_display_map.find(model.id);
+    return display_it == installed_display_map.end() ? model.id
+                                                     : display_it->second.title;
+  };
+  auto resolve_local_description = [&installed_display_map](
+                                      const ModelSummary &model) {
+    if (!model.description.empty()) {
+      return model.description;
+    }
+    const auto display_it = installed_display_map.find(model.id);
+    return display_it == installed_display_map.end()
+               ? std::string{}
+               : display_it->second.description;
+  };
 
   if (ctx.json_output) {
     nlohmann::json arr = nlohmann::json::array();
@@ -550,14 +568,12 @@ int RunAsrConfigListModels(bool available, Formatter &fmt, const CliContext &ctx
       } else if (model.state == ModelState::Broken) {
         status = "broken";
       }
-      const auto display_it = installed_display_map.find(model.id);
       arr.push_back({
           {"id", vinput::cli::HumanizeResourceId(installed_display_map,
                                                  model.id)},
           {"machine_id", model.id},
-          {"title", display_it == installed_display_map.end()
-                        ? model.id
-                        : display_it->second.title},
+          {"title", resolve_local_title(model)},
+          {"description", resolve_local_description(model)},
           {"model_type", model.model_type},
           {"language", model.language},
           {"supports_hotwords", model.supports_hotwords},
@@ -580,12 +596,9 @@ int RunAsrConfigListModels(bool available, Formatter &fmt, const CliContext &ctx
     } else if (model.state == ModelState::Broken) {
       status = std::string("[!] ") + _("Broken");
     }
-    const auto display_it = installed_display_map.find(model.id);
     rows.push_back({vinput::cli::HumanizeResourceId(installed_display_map,
                                                    model.id),
-                    display_it == installed_display_map.end()
-                        ? model.id
-                        : display_it->second.title,
+                    resolve_local_title(model),
                     model.model_type, model.language,
                     vinput::str::FormatSize(model.size_bytes),
                     model.supports_hotwords ? _("yes") : _("no"), status});

--- a/src/common/asr/model_manager.cpp
+++ b/src/common/asr/model_manager.cpp
@@ -159,6 +159,8 @@ ModelInfo ParseModelJson(const fs::path &dir, const fs::path &json_path,
     info.runtime = j.value("runtime", "");
     info.family = j.value("family", "");
     info.model_type = info.family;
+    info.title = j.value("title", "");
+    info.description = j.value("description", "");
     info.language = j.value("language", "auto");
     info.supports_hotwords = j.value("supports_hotwords", false);
     info.size_bytes = j.value("size_bytes", uint64_t{0});
@@ -525,6 +527,8 @@ ModelManager::ListDetailed(const std::string &active_model) const {
       json j;
       file >> j;
       s.model_type = j.value("family", "");
+      s.title = j.value("title", "");
+      s.description = j.value("description", "");
       s.language = j.value("language", "auto");
       s.supports_hotwords = j.value("supports_hotwords", false);
       s.size_bytes = j.value("size_bytes", uint64_t{0});

--- a/src/common/asr/model_manager.h
+++ b/src/common/asr/model_manager.h
@@ -12,6 +12,8 @@ struct ModelInfo {
   std::string runtime; // "online" or "offline"
   std::string family;  // sherpa-onnx C API family
   std::string model_type; // compatibility alias for family
+  std::string title;
+  std::string description;
   std::string language = "auto";
   bool supports_hotwords = false;
   uint64_t size_bytes = 0;
@@ -50,6 +52,8 @@ struct ModelSummary {
   std::string id;
   ModelState state;
   std::string model_type;
+  std::string title;
+  std::string description;
   std::string language;
   bool supports_hotwords = false;
   uint64_t size_bytes = 0;

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -12,6 +12,8 @@
 #include <QThreadPool>
 #include <QVBoxLayout>
 
+#include <algorithm>
+
 #include "common/utils/sandbox.h"
 #include "dialogs/asr_provider_dialog.h"
 #include "utils/gui_helpers.h"
@@ -19,6 +21,7 @@
 #include "common/audio/pipewire_device.h"
 #include "gui/utils/config_manager.h"
 #include "gui/utils/i18n_cache.h"
+#include "common/asr/model_manager.h"
 #include "cli/runtime/dbus_client.h"
 #include "cli/runtime/systemd_client.h"
 
@@ -36,6 +39,21 @@ bool ReloadAsrBackend(std::string *error = nullptr) {
     return daemon_error.empty();
   }
   return dbus.ReloadAsrBackend(error);
+}
+
+QString LocalModelTitle(const std::string &model_id, const CoreConfig &config,
+                        const vinput::registry::I18nMap &i18n_map) {
+  ModelManager manager(ResolveModelBaseDir(config).string());
+  const auto models = manager.ListDetailed(model_id);
+  const auto it = std::find_if(models.begin(), models.end(),
+                               [&model_id](const ModelSummary &model) {
+                                 return model.id == model_id;
+                               });
+  if (it != models.end() && !it->title.empty()) {
+    return QString::fromStdString(it->title);
+  }
+  return QString::fromStdString(
+      vinput::registry::LookupI18n(i18n_map, model_id + ".title", model_id));
 }
 
 bool GetAsrBackendState(vinput::dbus::AsrBackendState *state,
@@ -261,8 +279,7 @@ void ControlPage::populateAsrList(
     if (const auto *local = std::get_if<LocalAsrProvider>(&provider)) {
       QString model = QString::fromStdString(local->model);
       if (!model.isEmpty()) {
-        model = QString::fromStdString(vinput::registry::LookupI18n(
-            i18n_map, local->model + ".title", local->model));
+        model = LocalModelTitle(local->model, config, i18n_map);
       }
       display += " · " + (model.isEmpty() ? GuiTranslate("(not set)") : model);
     } else if (const auto *command = std::get_if<CommandAsrProvider>(&provider)) {

--- a/src/gui/pages/resources/resource_page.cpp
+++ b/src/gui/pages/resources/resource_page.cpp
@@ -37,6 +37,17 @@ void SetupTable(QTableWidget *t, const QStringList &headers) {
   t->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 }
 
+QString LocalModelTitle(const ModelSummary &model,
+                        const vinput::registry::I18nMap &i18n_map) {
+  if (!model.title.empty()) {
+    return QString::fromStdString(model.title);
+  }
+  QString id = QString::fromStdString(model.id);
+  QString titleStr = QString::fromStdString(
+      vinput::registry::LookupI18n(i18n_map, model.id + ".title", ""));
+  return titleStr.isEmpty() ? id : titleStr;
+}
+
 QLineEdit *CreateFilterEdit(const QString &placeholder, QWidget *parent) {
   auto *edit = new QLineEdit(parent);
   edit->setClearButtonEnabled(true);
@@ -263,8 +274,7 @@ void ResourcePage::populateLocalModels(const std::vector<ModelSummary> &models) 
 
   for (const auto &model : models) {
     QString id = QString::fromStdString(model.id);
-    QString titleStr = QString::fromStdString(vinput::registry::LookupI18n(i18n_map, model.id + ".title", ""));
-    QString title = titleStr.isEmpty() ? id : titleStr;
+    QString title = LocalModelTitle(model, i18n_map);
 
     int row = tableInstalledModels_->rowCount();
     tableInstalledModels_->insertRow(row);


### PR DESCRIPTION
## Summary

- Parse optional `title` and `description` fields from local `vinput-model.json` metadata
- Prefer local model titles when listing installed models in the CLI
- Use local titles in the GUI resources/control pages and the Fcitx ASR switch menu, falling back to registry i18n and then the model ID

## Why

Locally installed or experimental sherpa-onnx models can be detected and used without being present in the remote registry, but their display name currently falls back to the full model ID. Allowing local metadata keeps the CLI and GUI readable without requiring users to edit regenerated registry cache files.

## Validation

- `python3 scripts/check-i18n.py`
- `git diff --check`

Full CMake configuration could not be completed in my local environment because `ninja-build` and `libssl-dev` are not installed.
