### PR TITLE
feat: trim api_key when adding for convenience

### DIFF
--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -199,7 +199,7 @@ int RunLlmConfigAdd(const std::string &id, const std::string &baseUrl,
   LlmProvider provider;
   provider.id = id;
   provider.base_url = baseUrl;
-  provider.api_key = apiKey;
+  provider.api_key = vinput::str::TrimAsciiWhitespace(apiKey);
   provider.extra_body = std::move(extra_json);
   config.llm.providers.push_back(std::move(provider));
 
@@ -349,7 +349,7 @@ int RunLlmConfigEdit(const std::string &id, const std::string &baseUrl,
     it->base_url = baseUrl;
   }
   if (hasApiKey) {
-    it->api_key = apiKey;
+    it->api_key = vinput::str::TrimAsciiWhitespace(apiKey);
   }
   if (hasExtraBody) {
     nlohmann::json extra_json;

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -343,7 +343,7 @@ void LlmPage::onLlmAdd() {
   LlmProvider provider;
   provider.id = name_text.toStdString();
   provider.base_url = base_url_text.toStdString();
-  provider.api_key = editApiKey->text().toStdString();
+  provider.api_key = editApiKey->text().trimmed().toStdString();
   provider.extra_body = std::move(extra_body);
   config.llm.providers.push_back(std::move(provider));
 
@@ -413,8 +413,9 @@ void LlmPage::onLlmEdit() {
   auto it = std::find_if(providers.begin(), providers.end(), [&](const LlmProvider &p) { return p.id == provider_name.toStdString(); });
   if (it != providers.end()) {
       it->base_url = base_url_text.toStdString();
-      if (!editApiKey->text().isEmpty()) {
-          it->api_key = editApiKey->text().toStdString();
+      const QString api_key_text = editApiKey->text().trimmed();
+      if (!api_key_text.isEmpty()) {
+          it->api_key = api_key_text.toStdString();
       }
       it->extra_body = std::move(extra_body);
       if (!ConfigManager::Get().Save(config)) {


### PR DESCRIPTION
This PR trims the api_key when adding it for LLM providers. This helps with copying and pasting API keys (especially for vinput-gui).

A typical usage when adding an api_key is through:

```bash
$ load_private_infos
$ echo $DEEPSEEK_API_KEY | wl-copy
```

However, a `\n` is appended. When pasting into the GUI, `\n` is included. Then `curl` will fail strangely:

```
HTTP 400: Failed to parse the request body as JSON: expected value at line 1 column 1
```

This PR helps with such usage.