### PR TITLE
ci: 将 Nix Cachix 缓存拆出 channels

### DIFF
--- a/.github/workflows/channels.yml
+++ b/.github/workflows/channels.yml
@@ -15,7 +15,7 @@ on:
         description: Package version, for example 1.1.14
         required: true
       platform:
-        description: Platform to publish (all, copr, ppa, aur, flatpak, nix)
+        description: Platform to publish (all, copr, ppa, aur, flatpak)
         required: true
         default: all
         type: choice
@@ -25,7 +25,6 @@ on:
           - ppa
           - aur
           - flatpak
-          - nix
 
 permissions:
   contents: read
@@ -235,25 +234,3 @@ jobs:
             --field product=fcitx5-vinput \
             --field version=${{ inputs.version }} \
             --field force=true
-
-  nix-cachix:
-    if: ${{ inputs.platform == 'all' || inputs.platform == 'nix' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref }}
-
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v17
-        with:
-          name: fcitx5-vinput
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build and push to Cachix
-        run: nix build .#fcitx5-vinput --no-link

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,0 +1,35 @@
+name: nix-cache
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cachix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - uses: cachix/cachix-action@v17
+        with:
+          name: fcitx5-vinput
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build and push to Cachix
+        run: nix build .#fcitx5-vinput --no-link


### PR DESCRIPTION
## 背景

`nix-cachix` 的职责不是发布一个真正的 channel，也不是核心 CI 检查，而是为跟踪主分支 flake 的 Nix 用户预热 Cachix 缓存。

Nix 包的版本仍然完全由仓库中的 `flake.nix` / `flake.lock` 决定；Cachix 这里只提供对应 derivation 的二进制缓存，不改变版本选择，也不应和 PPA/COPR/AUR/Flatpak 这些发布渠道混在一起。

## 改动

- 从 `channels.yml` 移除 `nix` 平台选项和 `nix-cachix` job。
- 新增独立的 `nix-cache.yml` workflow。
- `nix-cache.yml` 在 `main` / `master` push 时自动构建 `.#fcitx5-vinput` 并推送到 Cachix，也保留手动触发入口。

## 验证

- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/nix-cache.yml`

补充：全仓 `actionlint` 目前会因为既有 workflow 中的 ShellCheck `SC2129` 风格告警失败，包含 `channels.yml` 和 `release.yml` 的已有脚本重定向写法；本 PR 新增的 `nix-cache.yml` 单独校验通过。
