### PR TITLE
packaging: PKGBUILD improvements

### DIFF
--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -4,10 +4,11 @@ pkgrel=@VINPUT_PKGREL@
 pkgdesc='Offline voice input addon for Fcitx5 with optional OpenAI-compatible postprocess'
 arch=('x86_64')
 url='@VINPUT_PKGURL@'
-license=('GPL3')
+license=('GPL-3.0-only')
 options=(!debug)
-depends=('curl' 'fcitx5' 'libarchive' 'openssl' 'pipewire' 'qt6-base' 'systemd-libs')
-makedepends=('clang' 'cli11' 'cmake' 'mold' 'ninja' 'nlohmann-json' 'pkgconf' 'qt6-tools' 'systemd')
+depends=('curl' 'fcitx5' 'libarchive' 'openssl' 'pipewire' 'qt6-base')
+makedepends=('clang' 'cli11' 'cmake' 'mold' 'ninja' 'nlohmann-json' 'pkgconf' 'qt6-tools')
+provides=("${pkgname}")
 source=('@VINPUT_SOURCE_ARCHIVE@')
 sha256sums=('@VINPUT_SOURCE_SHA256@')
 


### PR DESCRIPTION
Firstly, thanks for your awesome project. It allows me to use my laptop just like I would use TNT!

This PR contains some improvements to PKGBUILD:

1. systemd{,-libs} not need to be explicitly specified. They are dependent on the pseudo package "base", which is always installed on all Arch Linux systems.

   See also: https://gitlab.archlinux.org/archlinux/packaging/packages/base/-/blob/5795ef221c92455796f49565f4b2a005b9ac9a4b/PKGBUILD#L23

2. PKGBUILD should provide itself

3. "GPL3" is not a valid SPDX license name; use "GPL-3.0-only."

   See also https://spdx.org/licenses/