### PR TITLE
feat: reduce system output volume while recording (#105)

### DIFF
--- a/data/default-config.json
+++ b/data/default-config.json
@@ -9,7 +9,9 @@
   },
   "global": {
     "default_language": "zh",
-    "capture_device": "default"
+    "capture_device": "default",
+    "duck_output_while_recording": false,
+    "duck_output_volume": 0.25
   },
   "asr": {
     "active_provider": "sherpa-onnx",

--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -55,8 +55,56 @@
 <context>
     <name>vinput::gui::ControlPage</name>
     <message>
+        <source>&lt;b&gt;Audio&lt;/b&gt;</source>
+        <translation>&lt;b&gt;音频&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Capture Device:</source>
         <translation>录音设备：</translation>
+    </message>
+    <message>
+        <source>Normalize audio</source>
+        <translation>归一化音频</translation>
+    </message>
+    <message>
+        <source>Apply peak normalization to captured audio before recognition.</source>
+        <translation>在识别前对采集到的音频做峰值归一化。</translation>
+    </message>
+    <message>
+        <source>Input gain:</source>
+        <translation>输入增益：</translation>
+    </message>
+    <message>
+        <source>Microphone gain multiplier applied to captured audio.</source>
+        <translation>应用于采集音频的麦克风增益倍数。</translation>
+    </message>
+    <message>
+        <source>Trim silence (VAD)</source>
+        <translation>裁剪静音（VAD）</translation>
+    </message>
+    <message>
+        <source>Use voice activity detection to trim leading/trailing silence.</source>
+        <translation>使用语音活动检测裁剪首尾静音。</translation>
+    </message>
+    <message>
+        <source>Reduce output volume while recording</source>
+        <translation>录音时降低输出音量</translation>
+    </message>
+    <message>
+        <source>Lower the system output volume while recording, then restore it. Useful when speaker sound leaks into the microphone.</source>
+        <translation>录音时降低系统输出音量，结束后恢复。适用于外放声音被麦克风收入、干扰识别的情况。</translation>
+    </message>
+    <message>
+        <source>Output volume while recording:</source>
+        <translation>录音时的输出音量：</translation>
+    </message>
+    <message>
+        <source>Fraction of the current output volume to keep while recording.</source>
+        <translation>录音时保留的当前输出音量比例。</translation>
+    </message>
+    <message>
+        <source> %</source>
+        <translation> %</translation>
     </message>
     <message>
         <source>&lt;b&gt;ASR Providers&lt;/b&gt;</source>

--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -7,6 +7,7 @@ url='@VINPUT_PKGURL@'
 license=('GPL-3.0-only')
 options=(!debug)
 depends=('curl' 'fcitx5' 'libarchive' 'openssl' 'pipewire' 'qt6-base')
+optdepends=('wireplumber: reduce system output volume while recording')
 makedepends=('clang' 'cli11' 'cmake' 'mold' 'ninja' 'nlohmann-json' 'pkgconf' 'qt6-tools')
 provides=("${pkgname}")
 source=('@VINPUT_SOURCE_ARCHIVE@')

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -29,6 +29,7 @@ Homepage: https://github.com/xifan2333/fcitx5-vinput
 Package: fcitx5-vinput
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, fcitx5
+Recommends: wireplumber
 Description: Offline voice input addon for Fcitx5
  Local offline voice input plugin for Fcitx5, powered by sherpa-onnx
  for on-device speech recognition with optional LLM post-processing

--- a/packaging/fedora/fcitx5-vinput.spec
+++ b/packaging/fedora/fcitx5-vinput.spec
@@ -38,6 +38,7 @@ Requires:       pipewire
 Requires:       curl
 Requires:       systemd
 Requires:       qt6-qtbase
+Recommends:     wireplumber
 
 # Bundled sherpa-onnx/onnxruntime shared libraries are private runtime
 # dependencies installed under %{_libdir}/fcitx5-vinput/. They should not

--- a/packaging/opensuse/fcitx5-vinput.spec
+++ b/packaging/opensuse/fcitx5-vinput.spec
@@ -36,6 +36,7 @@ Requires:       fcitx5
 Requires:       pipewire
 Requires:       curl
 Requires:       systemd
+Recommends:     wireplumber
 
 %description
 Local offline voice input plugin for Fcitx5, powered by sherpa-onnx

--- a/site/src/content/docs/settings/index.md
+++ b/site/src/content/docs/settings/index.md
@@ -13,7 +13,9 @@ Corresponding config:
 {
   "global": {
     "default_language": "en",
-    "capture_device": "rnnoise_source"
+    "capture_device": "rnnoise_source",
+    "duck_output_while_recording": false,
+    "duck_output_volume": 0.25
   },
   "asr": {
     "normalize_audio": true,
@@ -63,6 +65,30 @@ VAD detects whether someone is speaking. When enabled, silent segments are filte
 ```bash
 vinput config set /asr/vad/enabled true
 ```
+
+## Reduce output volume while recording
+
+When `duck_output_while_recording` is enabled, Vinput lowers the system output
+volume while recording and restores it afterwards. This helps when you use
+speakers and a microphone at the same time — for example listening to music
+while dictating — so that speaker sound leaking into the microphone does not
+degrade recognition.
+
+`duck_output_volume` is the fraction of the current output volume kept while
+recording (`0.25` keeps 25%). It is clamped to the `0.0`–`1.0` range. This
+feature is off by default.
+
+Volume is adjusted through WirePlumber (`wpctl`), so it matches the system
+volume and is fully restored afterwards. If WirePlumber is not available (for
+example inside some sandboxes), the feature is silently skipped.
+
+```bash
+vinput config set /global/duck_output_while_recording true
+vinput config set /global/duck_output_volume 0.25
+```
+
+Both options are also available on the **Control** page in Vinput GUI, under the
+**Audio** section.
 
 ## Language
 

--- a/site/src/content/docs/zh-cn/settings/index.md
+++ b/site/src/content/docs/zh-cn/settings/index.md
@@ -13,7 +13,9 @@ description: 录音设备、增益、VAD 等基础配置。
 {
   "global": {
     "default_language": "en",
-    "capture_device": "rnnoise_source"
+    "capture_device": "rnnoise_source",
+    "duck_output_while_recording": false,
+    "duck_output_volume": 0.25
   },
   "asr": {
     "normalize_audio": true,
@@ -63,6 +65,21 @@ VAD 检测录音中是否有人在说话。开启后，静音片段会被自动�
 ```bash
 vinput config set /asr/vad/enabled true
 ```
+
+## 录音时降低输出音量
+
+开启 `duck_output_while_recording` 后，Vinput 会在录音期间降低系统输出音量，录音结束后自动恢复。适用于同时使用外放音箱和麦克风的场景——例如边听音乐边口述——避免外放声音被麦克风收进去、干扰识别。
+
+`duck_output_volume` 表示录音期间保留的音量比例（`0.25` 表示保留当前音量的 25%），取值会被限制在 `0.0`–`1.0` 之间。该功能默认关闭。
+
+音量通过 WirePlumber（`wpctl`）调节，因此与系统音量一致并在结束后完整恢复。若系统上没有 WirePlumber（例如某些沙箱环境），该功能会被静默跳过。
+
+```bash
+vinput config set /global/duck_output_while_recording true
+vinput config set /global/duck_output_volume 0.25
+```
+
+以上两项也可在 Vinput GUI 的 **控制** 页面 **音频** 分组中设置。
 
 ## 语言
 

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -155,11 +155,16 @@ void to_json(json &j, const CoreConfig::Global &g) {
   j = json::object();
   j["default_language"] = g.defaultLanguage;
   j["capture_device"] = g.captureDevice;
+  j["duck_output_while_recording"] = g.duckOutputWhileRecording;
+  j["duck_output_volume"] = g.duckOutputVolume;
 }
 
 void from_json(const json &j, CoreConfig::Global &g) {
   g.defaultLanguage = j.value("default_language", g.defaultLanguage);
   g.captureDevice = j.value("capture_device", g.captureDevice);
+  g.duckOutputWhileRecording =
+      j.value("duck_output_while_recording", g.duckOutputWhileRecording);
+  g.duckOutputVolume = j.value("duck_output_volume", g.duckOutputVolume);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/config/core_config_normalize.cpp
+++ b/src/common/config/core_config_normalize.cpp
@@ -1,5 +1,6 @@
 #include "common/config/core_config.h"
 
+#include <algorithm>
 #include <iostream>
 #include <iterator>
 #include <set>
@@ -87,6 +88,11 @@ void NormalizeCoreConfig(CoreConfig *config) {
   if (!config) {
     return;
   }
+
+  // Clamp audio-related knobs to sane ranges.
+  config->asr.inputGain = std::clamp(config->asr.inputGain, 0.1, 10.0);
+  config->global.duckOutputVolume =
+      std::clamp(config->global.duckOutputVolume, 0.0, 1.0);
 
   {
     std::set<std::string> seen;

--- a/src/common/config/core_config_types.h
+++ b/src/common/config/core_config_types.h
@@ -73,6 +73,8 @@ struct CoreConfig {
   struct Global {
     std::string defaultLanguage;
     std::string captureDevice;
+    bool duckOutputWhileRecording{false};
+    double duckOutputVolume{0.25};
   } global;
 
   struct Llm {

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(daemon
     asr/backends/command_streaming_backend.cpp
     audio/audio_capture.cpp
     audio/audio_utils.cpp
+    audio/output_ducker.cpp
     asr/vad_trimmer.cpp
     remote/remote_text_service.cpp
     runtime/dbus_service.cpp

--- a/src/daemon/audio/output_ducker.cpp
+++ b/src/daemon/audio/output_ducker.cpp
@@ -1,0 +1,109 @@
+#include "daemon/audio/output_ducker.h"
+
+#include "common/utils/debug_log.h"
+#include "common/utils/process_utils.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace vinput::daemon::audio {
+
+namespace {
+
+constexpr char kWpctl[] = "wpctl";
+constexpr char kDefaultSink[] = "@DEFAULT_AUDIO_SINK@";
+constexpr int kWpctlTimeoutMs = 2000;
+
+vinput::process::CommandResult RunWpctl(std::vector<std::string> args) {
+  vinput::process::CommandSpec spec;
+  spec.command = kWpctl;
+  spec.args = std::move(args);
+  spec.timeout_ms = kWpctlTimeoutMs;
+  return vinput::process::RunCommandWithInput(spec, {});
+}
+
+// Parse the numeric volume out of `wpctl get-volume` output, e.g.
+// "Volume: 1.00" or "Volume: 0.15 [MUTED]".
+std::optional<double> ParseVolume(const std::string &text) {
+  const auto pos = text.find("Volume:");
+  if (pos == std::string::npos) {
+    return std::nullopt;
+  }
+  const char *cursor = text.c_str() + pos + 7;  // skip "Volume:"
+  char *end = nullptr;
+  const double value = std::strtod(cursor, &end);
+  if (end == cursor) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+// Reads the current volume of the default sink. std::nullopt if wpctl is
+// unavailable or the output cannot be parsed.
+std::optional<double> ReadDefaultSinkVolume() {
+  const auto result = RunWpctl({"get-volume", kDefaultSink});
+  if (result.launch_failed || result.timed_out || result.exit_code != 0) {
+    return std::nullopt;
+  }
+  return ParseVolume(result.stdout_text);
+}
+
+bool SetDefaultSinkVolume(double volume) {
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "%.4f", volume);
+  const auto result = RunWpctl({"set-volume", kDefaultSink, buffer});
+  return !result.launch_failed && !result.timed_out && result.exit_code == 0;
+}
+
+}  // namespace
+
+void OutputDucker::Duck(double scale) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (ducked_) {
+    return;
+  }
+  scale = std::clamp(scale, 0.0, 1.0);
+
+  const auto current = ReadDefaultSinkVolume();
+  if (!current) {
+    fprintf(stderr,
+            "vinput-daemon: output ducking skipped (wpctl unavailable or no "
+            "default sink)\n");
+    return;
+  }
+
+  const double target = *current * scale;
+  if (!SetDefaultSinkVolume(target)) {
+    fprintf(stderr, "vinput-daemon: output ducking skipped (failed to set "
+                    "volume)\n");
+    return;
+  }
+
+  saved_volume_ = *current;
+  ducked_ = true;
+  vinput::debug::Log("ducked output volume %.2f -> %.2f (%.0f%%)\n", *current,
+                     target, scale * 100.0);
+}
+
+void OutputDucker::Restore() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!ducked_) {
+    return;
+  }
+  ducked_ = false;
+  const double restore_to = saved_volume_;
+  saved_volume_ = 0.0;
+  if (SetDefaultSinkVolume(restore_to)) {
+    vinput::debug::Log("restored output volume -> %.2f\n", restore_to);
+  } else {
+    fprintf(stderr,
+            "vinput-daemon: failed to restore output volume to %.2f\n",
+            restore_to);
+  }
+}
+
+}  // namespace vinput::daemon::audio

--- a/src/daemon/audio/output_ducker.h
+++ b/src/daemon/audio/output_ducker.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mutex>
+
+namespace vinput::daemon::audio {
+
+// Temporarily lowers the default audio sink volume while recording is active,
+// then restores it afterwards. Volume is driven through WirePlumber (wpctl) so
+// that it matches the system volume the user sees and hears, stays consistent
+// with the session manager, and is fully restorable. All operations are
+// best-effort: if wpctl is unavailable (e.g. a Flatpak sandbox) or fails, the
+// call is a no-op so that ducking can never block recording.
+class OutputDucker {
+public:
+  OutputDucker() = default;
+  ~OutputDucker() = default;
+
+  OutputDucker(const OutputDucker &) = delete;
+  OutputDucker &operator=(const OutputDucker &) = delete;
+
+  // Lower the default sink to (current_volume * scale). scale is clamped to
+  // [0.0, 1.0]. Idempotent: a second call while already ducked is a no-op.
+  void Duck(double scale);
+
+  // Restore the volume saved by the most recent Duck(). No-op if not ducked.
+  void Restore();
+
+private:
+  std::mutex mutex_;
+  bool ducked_ = false;
+  double saved_volume_ = 0.0;
+};
+
+}  // namespace vinput::daemon::audio

--- a/src/daemon/runtime/daemon_runtime_controller.cpp
+++ b/src/daemon/runtime/daemon_runtime_controller.cpp
@@ -397,8 +397,13 @@ DbusService::MethodResult DaemonRuntimeController::StartRecordingInternal(
 
   if (abort_started_capture) {
     capture_->EndRecording();
+    RestoreOutputIfDucked();
     ScheduleCaptureStopOnMainThread();
     return DbusService::MethodResult::Failure("Daemon is busy.");
+  }
+
+  if (runtime_settings.global.duckOutputWhileRecording) {
+    output_ducker_.Duck(runtime_settings.global.duckOutputVolume);
   }
 
   dbus_->EmitStatusChanged(
@@ -498,6 +503,7 @@ void DaemonRuntimeController::HandleIncomingAudio(std::span<const int16_t> pcm) 
           vinput::dbus::StatusToString(vinput::dbus::Status::Error));
       dbus_->EmitNotification(vinput::dbus::MakeRawError(push_error));
       capture_->EndRecording();
+      RestoreOutputIfDucked();
       ScheduleCaptureStopOnMainThread();
       return;
     }
@@ -555,6 +561,8 @@ void DaemonRuntimeController::EmitStreamingEvents(
   EmitRecognitionEvents(events, dbus_);
 }
 
+void DaemonRuntimeController::RestoreOutputIfDucked() { output_ducker_.Restore(); }
+
 void DaemonRuntimeController::ScheduleCaptureStopOnMainThread() {
   pending_capture_stop_.store(true, std::memory_order_release);
   if (notify_fd_ >= 0) {
@@ -583,6 +591,7 @@ DbusService::MethodResult DaemonRuntimeController::StopRecording(
   if (stop_capture) {
     capture_->EndRecording();
     captured_pcm = capture_->StopAndGetBuffer();
+    RestoreOutputIfDucked();
   }
 
   {
@@ -727,6 +736,7 @@ void DaemonRuntimeController::FlushDeferredActions() {
   }
 
   capture_->Stop();
+  RestoreOutputIfDucked();
   ResetToIdle();
 }
 
@@ -743,6 +753,7 @@ void DaemonRuntimeController::Shutdown() {
   accepting_chunks_.store(false, std::memory_order_relaxed);
   pending_capture_stop_.store(false, std::memory_order_relaxed);
   capture_->Stop();
+  RestoreOutputIfDucked();
   std::shared_ptr<vinput::daemon::asr::RecognitionSession> session_to_cancel;
   {
     std::lock_guard<std::mutex> lock(state_mutex_);
@@ -784,6 +795,7 @@ void DaemonRuntimeController::ResetToIdle() {
     first_non_silent_at_.reset();
     first_partial_logged_ = false;
   }
+  RestoreOutputIfDucked();
   dbus_->EmitStatusChanged(
       vinput::dbus::StatusToString(vinput::dbus::Status::Idle));
   vinput::debug::Log("phase -> idle\n");

--- a/src/daemon/runtime/daemon_runtime_controller.h
+++ b/src/daemon/runtime/daemon_runtime_controller.h
@@ -3,6 +3,7 @@
 #include "daemon/asr/runtime/recognition_contract.h"
 #include "daemon/asr/runtime/recognition_session_manager.h"
 #include "daemon/audio/audio_capture.h"
+#include "daemon/audio/output_ducker.h"
 #include "common/dbus/dbus_interface.h"
 #include "daemon/runtime/dbus_service.h"
 #include "daemon/runtime/recognition_pipeline.h"
@@ -55,6 +56,7 @@ private:
       vinput::daemon::asr::RecognitionSession *session,
       std::string *latest_partial_text = nullptr);
   void ScheduleCaptureStopOnMainThread();
+  void RestoreOutputIfDucked();
   std::shared_ptr<vinput::daemon::asr::RecognitionSession>
   ReleaseActiveSessionLocked();
   void SetPhase(vinput::dbus::Status new_phase);
@@ -63,6 +65,7 @@ private:
 
   AudioCapture *capture_ = nullptr;
   DbusService *dbus_ = nullptr;
+  vinput::daemon::audio::OutputDucker output_ducker_;
   vinput::daemon::asr::RecognitionSessionManager *recognition_manager_ = nullptr;
   RecognitionPipeline *pipeline_ = nullptr;
   vinput::daemon::remote::RemoteTextService *remote_text_service_ = nullptr;

--- a/src/gui/app/mainwindow.cpp
+++ b/src/gui/app/mainwindow.cpp
@@ -94,6 +94,13 @@ void MainWindow::onSaveClicked() {
     config.global.captureDevice.clear();
   }
 
+  // Save audio processing settings
+  config.asr.normalizeAudio = controlPage_->normalizeAudio();
+  config.asr.inputGain = controlPage_->inputGain();
+  config.asr.vad.enabled = controlPage_->vadEnabled();
+  config.global.duckOutputWhileRecording = controlPage_->duckOutputEnabled();
+  config.global.duckOutputVolume = controlPage_->duckOutputVolume();
+
   // Save hotwords
   QString hotwordsFile = hotwordPage_->hotwordsFilePath();
   for (auto& prov : config.asr.providers) {

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -1,8 +1,11 @@
 #include "pages/control/control_page.h"
 
+#include <QCheckBox>
+#include <QDoubleSpinBox>
 #include <QFormLayout>
 #include <QFrame>
 #include <QHBoxLayout>
+#include <QSpinBox>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -89,11 +92,54 @@ void RunGetAsrBackendStateAsync(ControlPage *page, Callback callback) {
 ControlPage::ControlPage(QWidget *parent) : QWidget(parent) {
   auto *layout = new QVBoxLayout(this);
 
+  // Audio section: capture device + audio processing knobs.
+  auto *audioFrame = new QFrame();
+  audioFrame->setFrameShape(QFrame::StyledPanel);
+  auto *audioLayout = new QVBoxLayout(audioFrame);
+  audioLayout->addWidget(new QLabel(tr("<b>Audio</b>")));
+
   auto *formLayout = new QFormLayout();
   comboDevice_ = new QComboBox();
   comboDevice_->setEditable(false);
   formLayout->addRow(tr("Capture Device:"), comboDevice_);
-  layout->addLayout(formLayout);
+
+  chkNormalizeAudio_ = new QCheckBox(tr("Normalize audio"));
+  chkNormalizeAudio_->setToolTip(
+      tr("Apply peak normalization to captured audio before recognition."));
+  formLayout->addRow(QString(), chkNormalizeAudio_);
+
+  spinInputGain_ = new QDoubleSpinBox();
+  spinInputGain_->setRange(0.1, 10.0);
+  spinInputGain_->setSingleStep(0.1);
+  spinInputGain_->setDecimals(1);
+  spinInputGain_->setToolTip(
+      tr("Microphone gain multiplier applied to captured audio."));
+  formLayout->addRow(tr("Input gain:"), spinInputGain_);
+
+  chkVadEnabled_ = new QCheckBox(tr("Trim silence (VAD)"));
+  chkVadEnabled_->setToolTip(
+      tr("Use voice activity detection to trim leading/trailing silence."));
+  formLayout->addRow(QString(), chkVadEnabled_);
+
+  chkDuckOutput_ = new QCheckBox(tr("Reduce output volume while recording"));
+  chkDuckOutput_->setToolTip(
+      tr("Lower the system output volume while recording, then restore it. "
+         "Useful when speaker sound leaks into the microphone."));
+  formLayout->addRow(QString(), chkDuckOutput_);
+
+  spinDuckVolume_ = new QSpinBox();
+  spinDuckVolume_->setRange(0, 100);
+  spinDuckVolume_->setSuffix(tr(" %"));
+  spinDuckVolume_->setToolTip(
+      tr("Fraction of the current output volume to keep while recording."));
+  formLayout->addRow(tr("Output volume while recording:"), spinDuckVolume_);
+
+  connect(chkDuckOutput_, &QCheckBox::toggled, spinDuckVolume_,
+          &QWidget::setEnabled);
+  spinDuckVolume_->setEnabled(chkDuckOutput_->isChecked());
+
+  audioLayout->addLayout(formLayout);
+  layout->addWidget(audioFrame);
 
   layout->addSpacing(20);
 
@@ -187,6 +233,14 @@ void ControlPage::reload() {
   CoreConfig config = ConfigManager::Get().Load();
   QString activeDevice = QString::fromStdString(config.global.captureDevice);
 
+  chkNormalizeAudio_->setChecked(config.asr.normalizeAudio);
+  spinInputGain_->setValue(config.asr.inputGain);
+  chkVadEnabled_->setChecked(config.asr.vad.enabled);
+  chkDuckOutput_->setChecked(config.global.duckOutputWhileRecording);
+  spinDuckVolume_->setValue(
+      static_cast<int>(config.global.duckOutputVolume * 100.0 + 0.5));
+  spinDuckVolume_->setEnabled(chkDuckOutput_->isChecked());
+
   for (const auto& dev : devices) {
     QString name = QString::fromStdString(dev.name);
     QString desc = QString::fromStdString(dev.description);
@@ -208,6 +262,22 @@ QString ControlPage::currentDevice() const {
   if (val.isEmpty())
     val = comboDevice_->currentText();
   return val;
+}
+
+bool ControlPage::normalizeAudio() const {
+  return chkNormalizeAudio_->isChecked();
+}
+
+double ControlPage::inputGain() const { return spinInputGain_->value(); }
+
+bool ControlPage::vadEnabled() const { return chkVadEnabled_->isChecked(); }
+
+bool ControlPage::duckOutputEnabled() const {
+  return chkDuckOutput_->isChecked();
+}
+
+double ControlPage::duckOutputVolume() const {
+  return spinDuckVolume_->value() / 100.0;
 }
 
 void ControlPage::refreshAsrList() {

--- a/src/gui/pages/control/control_page.h
+++ b/src/gui/pages/control/control_page.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <QCheckBox>
 #include <QComboBox>
+#include <QDoubleSpinBox>
 #include <QLabel>
 #include <QListWidget>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QTimer>
 #include <QWidget>
 
@@ -23,6 +26,13 @@ public:
 
   // Current device value for saving.
   QString currentDevice() const;
+
+  // Current audio-processing values for saving.
+  bool normalizeAudio() const;
+  double inputGain() const;
+  bool vadEnabled() const;
+  bool duckOutputEnabled() const;
+  double duckOutputVolume() const;
 
 signals:
   void configChanged();
@@ -46,6 +56,11 @@ private:
                        const vinput::dbus::AsrBackendState *backend_state);
 
   QComboBox *comboDevice_;
+  QCheckBox *chkNormalizeAudio_;
+  QDoubleSpinBox *spinInputGain_;
+  QCheckBox *chkVadEnabled_;
+  QCheckBox *chkDuckOutput_;
+  QSpinBox *spinDuckVolume_;
   QListWidget *listAsrProviders_;
   QPushButton *btnAsrEdit_;
   QPushButton *btnAsrRemove_;


### PR DESCRIPTION
Closes #105.

## What

Optional feature that lowers the system output volume while recording and restores it afterwards, so speaker sound leaking into the microphone no longer degrades recognition (e.g. dictating while music plays through speakers). **Off by default.**

## Config (`global`)

- `duck_output_while_recording` (bool, default `false`)
- `duck_output_volume` (fraction of current volume kept, default `0.25`; clamped to `0.0`–`1.0`)
- `input_gain` is now also clamped in normalize.

## Daemon

- New `OutputDucker` drives volume through **WirePlumber** (`wpctl get/set-volume @DEFAULT_AUDIO_SINK@`): read + scale on record start, restore on stop. This targets the same volume the user sees/hears and is fully restorable. Best-effort — no-op if `wpctl` is unavailable (e.g. Flatpak sandbox), so ducking can never block recording.
- Ducks on entering `Recording`; restores idempotently on every capture-stop / error / reset / shutdown path.

> Note: an earlier approach set the sink node's `channelVolumes` directly, but on WirePlumber-managed hardware-volume sinks that is a secondary software gain that is neither audible nor what the user-facing "system volume" (device Route) reflects. Driving WirePlumber is the correct, consistent knob.

## GUI

- Surfaces audio processing on the Control page under a new **Audio** group (capture device, normalize audio, input gain, VAD, output ducking), with zh_CN translations.

## Packaging / docs

- Declare `wireplumber` as a weak/runtime helper dependency (`optdepends` on Arch, `Recommends` on deb/rpm) for output ducking.
- Document the new options and the WirePlumber requirement (en + zh).

## Testing

- All release build jobs pass (tarball, deb ubuntu/debian, rpm fedora/opensuse, arch, flatpak).
- Installed the Arch build locally and verified duck-on-record / restore-on-stop works with speakers + mic.
