### PR TITLE
fix(config): preserve defaults when saving

### DIFF
--- a/src/addon/core/vinput.cpp
+++ b/src/addon/core/vinput.cpp
@@ -10,6 +10,7 @@
 #include "dbus/notifier_dbus_object.h"
 
 #include <dbus_public.h>
+#include <fcitx-config/iniparser.h>
 #include <fcitx-utils/event.h>
 #include <fcitx/inputcontext.h>
 
@@ -191,31 +192,32 @@ VinputEngine::~VinputEngine() {
 }
 
 void VinputEngine::reloadConfig() {
-  settings_ = LoadVinputSettings();
+  fcitx::readAsIni(config_, kVinputConfigPath);
   applySettings();
 }
 
-void VinputEngine::save() { SaveVinputSettings(settings_); }
+void VinputEngine::save() {
+  fcitx::safeSaveAsIni(config_, kVinputConfigPath);
+}
 
 const fcitx::Configuration *VinputEngine::getConfig() const {
-  rebuildUiConfig();
-  return ui_config_.get();
+  return &config_;
 }
 
 void VinputEngine::setConfig(const fcitx::RawConfig &rawConfig) {
-  auto config = std::make_unique<VinputConfig>(settings_);
-  config->load(rawConfig, true);
-  settings_ = config->settings();
+  config_.load(rawConfig, true);
   applySettings();
-  SaveVinputSettings(settings_);
+  save();
 }
 
 void VinputEngine::applySettings() {
-  trigger_keys_ = settings_.triggerKeys;
-  command_keys_ = settings_.commandKeys;
-  scene_menu_key_ = settings_.sceneMenuKeys;
-  asr_menu_key_ = settings_.asrMenuKeys;
-  trigger_mode_ = settings_.triggerMode;
+  trigger_keys_ = config_.triggerKeys.value();
+  command_keys_ = config_.commandKeys.value();
+  scene_menu_key_ = config_.sceneMenuKeys.value();
+  asr_menu_key_ = config_.asrMenuKeys.value();
+  page_prev_keys_ = config_.pagePrevKeys.value();
+  page_next_keys_ = config_.pageNextKeys.value();
+  trigger_mode_ = config_.triggerMode.value();
   reloadSceneConfig();
   reloadAsrMenuItems();
 }
@@ -233,10 +235,6 @@ void VinputEngine::reloadSceneConfig() {
     }
   }
   max_context_lines_ = max_cl;
-}
-
-void VinputEngine::rebuildUiConfig() const {
-  ui_config_ = std::make_unique<VinputConfig>(settings_);
 }
 
 void VinputEngine::rememberInputContext(fcitx::InputContext *ic) {

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -48,7 +48,6 @@ public:
 private:
   void applySettings();
   void reloadSceneConfig();
-  void rebuildUiConfig() const;
   void handleKeyEvent(fcitx::Event &event);
   void showSceneMenu(fcitx::InputContext *ic);
   void hideSceneMenu();
@@ -185,8 +184,7 @@ private:
   std::unique_ptr<fcitx::EventSourceTime> pending_stop_event_;
   std::unique_ptr<fcitx::EventSourceTime> pending_start_event_;
   std::unique_ptr<fcitx::EventSourceTime> status_sync_event_;
-  VinputSettings settings_;
-  mutable std::unique_ptr<VinputConfig> ui_config_;
+  VinputConfig config_;
   int commit_write_count_ = 0;
   TriggerMode trigger_mode_{TriggerMode::Both};
 };

--- a/src/common/config/vinput_config.cpp
+++ b/src/common/config/vinput_config.cpp
@@ -2,7 +2,6 @@
 
 #include "common/i18n.h"
 
-#include <fcitx-config/iniparser.h>
 #include <fcitx-utils/standardpath.h>
 
 #include <filesystem>
@@ -88,57 +87,32 @@ std::string TriggerModeLabel() { return _("Trigger Mode"); }
 
 } // namespace
 
-VinputConfig::VinputConfig(const VinputSettings &settings)
+VinputConfig::VinputConfig()
     : triggerMode(this, "TriggerMode", TriggerModeLabel(),
-                  settings.triggerMode, {}, {},
-                  TriggerModeI18NAnnotation()),
-      triggerKeys(this, "TriggerKey", TriggerKeyLabel(), settings.triggerKeys,
-                 TriggerKeyListConstrain(), {},
-                 fcitx::ToolTipAnnotation(TriggerKeyTooltip())),
-      commandKeys(this, "CommandKeys", CommandKeysLabel(), settings.commandKeys,
+                  TriggerMode::Both, {}, {}, TriggerModeI18NAnnotation()),
+      triggerKeys(this, "TriggerKey", TriggerKeyLabel(),
+                  {fcitx::Key(FcitxKey_Alt_R)}, TriggerKeyListConstrain(),
+                  {}, fcitx::ToolTipAnnotation(TriggerKeyTooltip())),
+      commandKeys(this, "CommandKeys", CommandKeysLabel(),
+                  {fcitx::Key(FcitxKey_Control_R)},
                   TriggerKeyListConstrain(), {},
                   fcitx::ToolTipAnnotation(CommandKeysTooltip())),
       sceneMenuKeys(this, "SceneMenuKey", SceneMenuKeyLabel(),
-                   settings.sceneMenuKeys, SceneMenuKeyListConstrain(), {},
+                   {fcitx::Key(FcitxKey_Shift_R)},
+                   SceneMenuKeyListConstrain(), {},
                    fcitx::ToolTipAnnotation(SceneMenuKeyTooltip())),
       asrMenuKeys(this, "AsrMenuKey", AsrMenuKeyLabel(),
-                  settings.asrMenuKeys, SceneMenuKeyListConstrain(), {},
+                  {fcitx::Key(FcitxKey_F8)}, SceneMenuKeyListConstrain(), {},
                   fcitx::ToolTipAnnotation(AsrMenuKeyTooltip())),
       pagePrevKeys(this, "PagePrevKeys", PagePrevKeysLabel(),
-                   settings.pagePrevKeys, TriggerKeyListConstrain(), {},
+                   {fcitx::Key(FcitxKey_Page_Up),
+                    fcitx::Key(FcitxKey_KP_Page_Up)},
+                   TriggerKeyListConstrain(), {},
                    fcitx::ToolTipAnnotation(PagePrevKeysTooltip())),
       pageNextKeys(this, "PageNextKeys", PageNextKeysLabel(),
-                   settings.pageNextKeys, TriggerKeyListConstrain(), {},
+                   {fcitx::Key(FcitxKey_Page_Down),
+                    fcitx::Key(FcitxKey_KP_Page_Down)},
+                   TriggerKeyListConstrain(), {},
                    fcitx::ToolTipAnnotation(PageNextKeysTooltip())),
       modelManager(this, "ModelManager", _("Open Vinput Settings"),
                    "vinput-gui") {}
-
-VinputSettings VinputConfig::settings() const {
-  VinputSettings settings;
-  settings.triggerKeys = triggerKeys.value();
-  settings.commandKeys = commandKeys.value();
-  settings.sceneMenuKeys = sceneMenuKeys.value();
-  settings.asrMenuKeys = asrMenuKeys.value();
-  settings.pagePrevKeys = pagePrevKeys.value();
-  settings.pageNextKeys = pageNextKeys.value();
-  settings.triggerMode = triggerMode.value();
-  return settings;
-}
-
-VinputSettings LoadVinputSettings() {
-  VinputConfig config(VinputSettings{});
-  fcitx::readAsIni(config, fcitx::StandardPath::Type::PkgConfig,
-                   kVinputConfigPath);
-  return config.settings();
-}
-
-bool SaveVinputSettings(const VinputSettings &settings) {
-  VinputConfig config(settings);
-  return fcitx::safeSaveAsIni(config, fcitx::StandardPath::Type::PkgConfig,
-                              kVinputConfigPath);
-}
-
-std::unique_ptr<VinputConfig>
-BuildVinputConfig(const VinputSettings &settings) {
-  return std::make_unique<VinputConfig>(settings);
-}

--- a/src/common/config/vinput_config.h
+++ b/src/common/config/vinput_config.h
@@ -6,39 +6,18 @@
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/key.h>
 
-#include <memory>
-
 inline constexpr const char *kVinputConfigPath = "conf/vinput.conf";
 
 FCITX_CONFIG_ENUM(TriggerMode, Tap, Hold, Both)
 FCITX_CONFIG_ENUM_I18N_ANNOTATION(TriggerMode, N_("Tap"), N_("Hold"), N_("Both"))
 
-struct VinputSettings {
-  fcitx::KeyList triggerKeys{fcitx::Key(FcitxKey_Alt_R)};
-  fcitx::KeyList commandKeys{fcitx::Key(FcitxKey_Control_R)};
-  fcitx::KeyList sceneMenuKeys{
-      fcitx::Key(FcitxKey_Shift_R)};
-  fcitx::KeyList asrMenuKeys{
-      fcitx::Key(FcitxKey_F8)};
-  fcitx::KeyList pagePrevKeys{
-      fcitx::Key(FcitxKey_Page_Up),
-      fcitx::Key(FcitxKey_KP_Page_Up),
-  };
-  fcitx::KeyList pageNextKeys{
-      fcitx::Key(FcitxKey_Page_Down),
-      fcitx::Key(FcitxKey_KP_Page_Down),
-  };
-  TriggerMode triggerMode{TriggerMode::Both};
-};
-
 class VinputConfig : public fcitx::Configuration {
 public:
-  VinputConfig(const VinputSettings &settings);
+  VinputConfig();
   VinputConfig(const VinputConfig &) = delete;
   VinputConfig &operator=(const VinputConfig &) = delete;
 
   const char *typeName() const override { return "VinputConfig"; }
-  VinputSettings settings() const;
 
   fcitx::Option<TriggerMode, fcitx::NoConstrain<TriggerMode>,
                 fcitx::DefaultMarshaller<TriggerMode>,
@@ -77,7 +56,3 @@ public:
 
   fcitx::ExternalOption modelManager;
 };
-
-VinputSettings LoadVinputSettings();
-bool SaveVinputSettings(const VinputSettings &settings);
-std::unique_ptr<VinputConfig> BuildVinputConfig(const VinputSettings &settings);


### PR DESCRIPTION
This fixes a config persistence issue exposed by unreleased fcitx5 changes.

Recent fcitx5 now marks config entries as implicit when their current value is
equal to the option default, and implicit entries are written as commented
defaults in the generated ini file. This assumes that each option's default
value represents the real schema default.

Vinput previously rebuilt VinputConfig from the current runtime settings when
saving. That made fcitx treat user-configured values as option defaults, so
custom hotkeys could be written back as commented implicit defaults and ignored
on the next startup.

This PR keeps VinputConfig as the addon's configuration object and declares
defaults directly on the fcitx options, matching the usual fcitx addon config
pattern.