### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For ASR configuration, scenes & LLM setup, CLI reference, and registry contribut
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xifan2333/fcitx5-vinput&type=Date)](https://star-history.com/#xifan2333/fcitx5-vinput&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xifan2333/fcitx5-vinput&type=Date)](https://star-history.dera.page/#xifan2333/fcitx5-vinput&Date)
 
 ## Contributors
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -153,7 +153,7 @@ ASR 配置、场景与 LLM、CLI 参考和资源仓库贡献规范请查看[文�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xifan2333/fcitx5-vinput&type=Date)](https://star-history.com/#xifan2333/fcitx5-vinput&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xifan2333/fcitx5-vinput&type=Date)](https://star-history.dera.page/#xifan2333/fcitx5-vinput&Date)
 
 ## 贡献者
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This switches the chart to a working alternative that does not require an API token, so the chart renders correctly again.