### PR TITLE
fix(llm): avoid dangling view while parsing candidates

### DIFF
--- a/src/daemon/postprocess/post_processor.cpp
+++ b/src/daemon/postprocess/post_processor.cpp
@@ -178,9 +178,10 @@ std::vector<std::string> ExtractCandidates(const json& response) {
     if (!value.is_string()) {
       continue;
     }
-    const auto candidate = TrimAsciiWhitespace(value.get<std::string>());
-    if (!candidate.empty()) {
-      candidates.emplace_back(candidate);
+    const auto candidate_text = value.get<std::string>();
+    const auto trimmed_candidate = TrimAsciiWhitespace(candidate_text);
+    if (!trimmed_candidate.empty()) {
+      candidates.emplace_back(trimmed_candidate);
     }
   }
 


### PR DESCRIPTION
## Summary

Fix a dangling `std::string_view` while extracting LLM response candidates.

`TrimAsciiWhitespace()` returns a view, but it was previously given a temporary string that was destroyed before the view was copied. This could corrupt candidate text and later cause invalid UTF-8 errors.

Keep the JSON string alive until the trimmed candidate is copied.

## Testing

The project builds and the existing test suite passes.