### PR TITLE
docs: document lite mode across all distros, channels, and download components (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ yay -S fcitx5-vinput-lite-bin
 
 ```bash
 sudo dnf copr enable xifan/fcitx5-vinput-bin
+
+# Full version (with local sherpa-onnx runtime)
 sudo dnf install fcitx5-vinput
+
+# Lite version (cloud-only, zero local ONNX runtime)
+sudo dnf install fcitx5-vinput-lite
 ```
 
 ### Ubuntu 24.04 (PPA)
@@ -57,14 +62,24 @@ sudo dnf install fcitx5-vinput
 ```bash
 sudo add-apt-repository ppa:xifan233/ppa
 sudo apt update
+
+# Full version (with local sherpa-onnx runtime)
 sudo apt install fcitx5-vinput
+
+# Lite version (cloud-only, zero local ONNX runtime)
+sudo apt install fcitx5-vinput-lite
 ```
 
 ### Ubuntu / Debian (manual)
 
 ```bash
 # Download latest .deb from GitHub Releases
+# Full version (with local sherpa-onnx runtime):
 sudo dpkg -i fcitx5-vinput_*.deb
+sudo apt-get install -f
+
+# Lite version (cloud-only, zero local ONNX runtime):
+sudo dpkg -i fcitx5-vinput-lite_*.deb
 sudo apt-get install -f
 ```
 
@@ -96,7 +111,12 @@ Full Home Manager example in the [install docs](https://xifan2333.github.io/fcit
 
 ```bash
 flatpak remote-add --if-not-exists xifan https://xifan2333.github.io/flatpak-auto/xifan.flatpakrepo
+
+# Full version (with local sherpa-onnx runtime)
 flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.flatpakref
+
+# Lite version (cloud-only, zero local ONNX runtime)
+flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.Lite.flatpakref
 ```
 
 After installation, grant the extra permissions and restart Fcitx5:
@@ -110,21 +130,27 @@ flatpak kill org.fcitx.Fcitx5
 
 ### GitHub Releases
 
-Download the package for your system from [GitHub Releases](https://github.com/xifan2333/fcitx5-vinput/releases/latest):
+Download the package for your system from [GitHub Releases](https://github.com/xifan2333/fcitx5-vinput/releases/latest) (both full and lite variants are provided):
 
-- **Debian / Linux Mint / Ubuntu (other)**: `.deb`
-- **openSUSE / Fedora (other)**: `.rpm`
-- **Arch-based**: `.pkg.tar.zst`
-- **Flatpak**: `.flatpak`
-- **Generic Linux**: `_bundled.tar.gz`
+- **Debian / Linux Mint / Ubuntu (other)**: `.deb` (`fcitx5-vinput_*.deb` / `fcitx5-vinput-lite_*.deb`)
+- **openSUSE / Fedora (other)**: `.rpm` (`fcitx5-vinput-*.rpm` / `fcitx5-vinput-lite-*.rpm`)
+- **Arch-based**: `.pkg.tar.zst` (`fcitx5-vinput-*.pkg.tar.zst` / `fcitx5-vinput-lite-*.pkg.tar.zst`)
+- **Flatpak**: `.flatpak` (`fcitx5-vinput.flatpak` / `fcitx5-vinput-lite.flatpak`)
+- **Generic Linux**: `tar.gz` (`*_bundled.tar.gz` / `fcitx5-vinput-lite-*.tar.gz`)
 
 ### Build from source
 
 **Dependencies:** cmake, fcitx5, pipewire, libcurl, nlohmann-json, CLI11, Qt6
 
 ```bash
+# Full version (with local sherpa-onnx ASR runtime)
 sudo bash scripts/build-sherpa-onnx.sh
 cmake --preset release-clang-mold
+cmake --build --preset release-clang-mold
+sudo cmake --install build
+
+# Lite version (pure cloud ASR + LLM, zero sherpa-onnx dependency)
+cmake --preset release-clang-mold -DVINPUT_ENABLE_LOCAL_ASR=OFF
 cmake --build --preset release-clang-mold
 sudo cmake --install build
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -49,7 +49,12 @@ yay -S fcitx5-vinput-lite-bin
 
 ```bash
 sudo dnf copr enable xifan/fcitx5-vinput-bin
+
+# 完整版（带本地 sherpa-onnx 离线推理）
 sudo dnf install fcitx5-vinput
+
+# 极简 Lite 版（纯云端 ASR + LLM，无本地 ONNX 运行时）
+sudo dnf install fcitx5-vinput-lite
 ```
 
 ### Ubuntu 24.04 (PPA)
@@ -57,14 +62,24 @@ sudo dnf install fcitx5-vinput
 ```bash
 sudo add-apt-repository ppa:xifan233/ppa
 sudo apt update
+
+# 完整版（带本地 sherpa-onnx 离线推理）
 sudo apt install fcitx5-vinput
+
+# 极简 Lite 版（纯云端 ASR + LLM，无本地 ONNX 运行时）
+sudo apt install fcitx5-vinput-lite
 ```
 
 ### Ubuntu / Debian（手动安装）
 
 ```bash
 # 从 GitHub Releases 下载最新 .deb
+# 完整版（带本地 sherpa-onnx 离线推理）：
 sudo dpkg -i fcitx5-vinput_*.deb
+sudo apt-get install -f
+
+# 极简 Lite 版（纯云端 ASR + LLM，无本地 ONNX 运行时）：
+sudo dpkg -i fcitx5-vinput-lite_*.deb
 sudo apt-get install -f
 ```
 
@@ -96,7 +111,12 @@ nixConfig = {
 
 ```bash
 flatpak remote-add --if-not-exists xifan https://xifan2333.github.io/flatpak-auto/xifan.flatpakrepo
+
+# 完整版（带本地 sherpa-onnx 离线推理）
 flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.flatpakref
+
+# 极简 Lite 版（纯云端 ASR + LLM，零本地 ONNX 运行时）
+flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.Lite.flatpakref
 ```
 
 安装后需要授予额外权限并重启 Fcitx5：
@@ -110,21 +130,27 @@ flatpak kill org.fcitx.Fcitx5
 
 ### GitHub Releases
 
-从 [GitHub Releases](https://github.com/xifan2333/fcitx5-vinput/releases/latest) 下载对应安装包：
+从 [GitHub Releases](https://github.com/xifan2333/fcitx5-vinput/releases/latest) 下载对应安装包（均提供完整版与 Lite 极简版）：
 
-- **Debian / Linux Mint / Ubuntu（其他版本）**：`.deb`
-- **openSUSE / Fedora（其他版本）**：`.rpm`
-- **Arch 系**：`.pkg.tar.zst`
-- **Flatpak**：`.flatpak`
-- **通用 Linux**：`_bundled.tar.gz`
+- **Debian / Linux Mint / Ubuntu（其他版本）**：`.deb`（`fcitx5-vinput_*.deb` / `fcitx5-vinput-lite_*.deb`）
+- **openSUSE / Fedora（其他版本）**：`.rpm`（`fcitx5-vinput-*.rpm` / `fcitx5-vinput-lite-*.rpm`）
+- **Arch 系**：`.pkg.tar.zst`（`fcitx5-vinput-*.pkg.tar.zst` / `fcitx5-vinput-lite-*.pkg.tar.zst`）
+- **Flatpak**：`.flatpak`（`fcitx5-vinput.flatpak` / `fcitx5-vinput-lite.flatpak`）
+- **通用 Linux**：`tar.gz`（`*_bundled.tar.gz` / `fcitx5-vinput-lite-*.tar.gz`）
 
 ### 源码构建
 
 **依赖：** cmake、fcitx5、pipewire、libcurl、nlohmann-json、CLI11、Qt6
 
 ```bash
+# 完整版（带本地 sherpa-onnx 离线推理引擎）
 sudo bash scripts/build-sherpa-onnx.sh
 cmake --preset release-clang-mold
+cmake --build --preset release-clang-mold
+sudo cmake --install build
+
+# 极简 Lite 版（纯云端 ASR + LLM，零 sherpa-onnx 依赖）
+cmake --preset release-clang-mold -DVINPUT_ENABLE_LOCAL_ASR=OFF
 cmake --build --preset release-clang-mold
 sudo cmake --install build
 ```

--- a/site/src/components/ReleaseDownloads.astro
+++ b/site/src/components/ReleaseDownloads.astro
@@ -37,11 +37,16 @@ class ReleaseDownloads extends HTMLElement {
       .map((a) => ({ name: a.name, url: a.browser_download_url, label: labelFor(a.name, zh) }))
       .filter((a): a is { name: string; url: string; label: string } => a.label != null);
 
-    const order = ['Arch', 'Ubuntu', 'Debian', 'Fedora', 'RPM', 'Flatpak', 'Generic', '通用', 'Source', '源'];
+    const order = ['Arch', 'Ubuntu', 'Debian', 'Fedora', 'RPM', 'Flatpak', 'Generic', '通用', 'Source', '源', '源代'];
     assets.sort((a, b) => {
       const ai = order.findIndex((o) => a.label.startsWith(o));
       const bi = order.findIndex((o) => b.label.startsWith(o));
-      return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+      const primary = (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+      if (primary !== 0) return primary;
+      const aLite = a.name.includes('lite') ? 1 : 0;
+      const bLite = b.name.includes('lite') ? 1 : 0;
+      if (aLite !== bLite) return aLite - bLite;
+      return a.name.localeCompare(b.name);
     });
 
     const tag = release.tag_name;
@@ -58,13 +63,17 @@ class ReleaseDownloads extends HTMLElement {
 }
 
 function labelFor(name: string, zh: boolean): string | null {
-  if (name.endsWith('.pkg.tar.zst')) return 'Arch Linux';
-  if (/ubuntu.*\.deb$/.test(name)) return 'Ubuntu 24.04';
-  if (/debian.*\.deb$/.test(name)) return 'Debian 12';
-  if (/\.fc\d+\..*\.rpm$/.test(name)) return 'Fedora';
-  if (/\.rpm$/.test(name)) return zh ? 'RPM（通用）' : 'RPM (generic)';
-  if (name.endsWith('.flatpak')) return 'Flatpak';
-  if (/bundled\.tar\.gz$/.test(name)) return zh ? '通用 Linux（捆绑包）' : 'Generic Linux (bundled)';
+  const isLite = name.includes('lite') || name.includes('-lite');
+  const suffix = isLite ? (zh ? '（Lite 极简版）' : ' (Lite)') : '';
+
+  if (name.endsWith('.pkg.tar.zst')) return `Arch Linux${suffix}`;
+  if (/ubuntu.*\.deb$/.test(name)) return `Ubuntu 24.04${suffix}`;
+  if (/debian.*\.deb$/.test(name)) return `Debian 12${suffix}`;
+  if (/\.fc\d+\..*\.rpm$/.test(name)) return `Fedora${suffix}`;
+  if (/\.rpm$/.test(name)) return zh ? `RPM（通用${isLite ? ' Lite' : ''}）` : `RPM (generic${isLite ? ' Lite' : ''})`;
+  if (name.endsWith('.flatpak')) return `Flatpak${suffix}`;
+  if (/bundled\.tar\.gz$/.test(name)) return zh ? '通用 Linux（捆绑完整版）' : 'Generic Linux (bundled)';
+  if (isLite && name.endsWith('.tar.gz')) return zh ? '通用 Linux（Lite 极简版）' : 'Generic Linux (Lite)';
   if (name.endsWith('.tar.gz')) return zh ? '源代码' : 'Source code';
   return null;
 }

--- a/site/src/content/docs/install/index.mdx
+++ b/site/src/content/docs/install/index.mdx
@@ -29,7 +29,12 @@ yay -S fcitx5-vinput-lite-bin
 
 ```bash
 sudo dnf copr enable xifan/fcitx5-vinput-bin
+
+# Full version (with local sherpa-onnx runtime)
 sudo dnf install fcitx5-vinput
+
+# Lite version (cloud-only, zero local ONNX runtime)
+sudo dnf install fcitx5-vinput-lite
 ```
 
 ### Ubuntu 24.04 (PPA)
@@ -37,7 +42,12 @@ sudo dnf install fcitx5-vinput
 ```bash
 sudo add-apt-repository ppa:xifan233/ppa
 sudo apt update
+
+# Full version (with local sherpa-onnx runtime)
 sudo apt install fcitx5-vinput
+
+# Lite version (cloud-only, zero local ONNX runtime)
+sudo apt install fcitx5-vinput-lite
 ```
 
 ### Nix (flake)
@@ -124,7 +134,12 @@ in
 
 ```bash
 flatpak remote-add --if-not-exists xifan https://xifan2333.github.io/flatpak-auto/xifan.flatpakrepo
+
+# Full version (with local sherpa-onnx runtime)
 flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.flatpakref
+
+# Lite version (cloud-only, zero local ONNX runtime)
+flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.Lite.flatpakref
 ```
 
 After installation, grant additional permissions and restart Fcitx5:
@@ -138,7 +153,7 @@ flatpak kill org.fcitx.Fcitx5
 
 ## Local install
 
-Download the package for your distribution and install it directly.
+Download the package for your distribution and install it directly. Both **Full** (with local offline sherpa-onnx runtime) and **Lite** (cloud ASR + LLM only) packages are provided.
 
 <ReleaseDownloads lang="en" />
 
@@ -148,10 +163,13 @@ After downloading:
 - **`.rpm`**: `sudo dnf install <file>.rpm`
 - **`.pkg.tar.zst`**: `sudo pacman -U <file>.pkg.tar.zst`
 - **`.flatpak`**: `flatpak install <file>.flatpak`
+- **`.tar.gz`**: Extract and follow bundled install instructions
 
 ## Build from source
 
 **Dependencies:** cmake, fcitx5, pipewire, libcurl, nlohmann-json, CLI11, Qt6
+
+### Full version (with local sherpa-onnx runtime)
 
 ```bash
 sudo bash scripts/build-sherpa-onnx.sh
@@ -170,5 +188,13 @@ sudo mise run install
 ```
 
 The first step downloads the pre-built sherpa-onnx runtime used by local builds and release packaging. Runtime libraries are bundled with the installed artifacts instead of being declared as a separate system package dependency.
+
+### Lite version (pure cloud ASR + LLM, zero sherpa-onnx dependency)
+
+```bash
+cmake --preset release-clang-mold -DVINPUT_ENABLE_LOCAL_ASR=OFF
+cmake --build --preset release-clang-mold
+sudo cmake --install build
+```
 
 Source builds default to the Fcitx5 system prefix (`/usr`) so the addon is installed under the directories Fcitx5 scans.

--- a/site/src/content/docs/zh-cn/install/index.mdx
+++ b/site/src/content/docs/zh-cn/install/index.mdx
@@ -29,7 +29,12 @@ yay -S fcitx5-vinput-lite-bin
 
 ```bash
 sudo dnf copr enable xifan/fcitx5-vinput-bin
+
+# 完整版（带本地 sherpa-onnx 离线推理）
 sudo dnf install fcitx5-vinput
+
+# 极简 Lite 版（纯云端 ASR + LLM，无本地 ONNX 运行时）
+sudo dnf install fcitx5-vinput-lite
 ```
 
 ### Ubuntu 24.04 (PPA)
@@ -37,7 +42,12 @@ sudo dnf install fcitx5-vinput
 ```bash
 sudo add-apt-repository ppa:xifan233/ppa
 sudo apt update
+
+# 完整版（带本地 sherpa-onnx 离线推理）
 sudo apt install fcitx5-vinput
+
+# 极简 Lite 版（纯云端 ASR + LLM，无本地 ONNX 运行时）
+sudo apt install fcitx5-vinput-lite
 ```
 
 ### Nix (flake)
@@ -124,7 +134,12 @@ in
 
 ```bash
 flatpak remote-add --if-not-exists xifan https://xifan2333.github.io/flatpak-auto/xifan.flatpakrepo
+
+# 完整版（带本地 sherpa-onnx 离线推理）
 flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.flatpakref
+
+# 极简 Lite 版（纯云端 ASR + LLM，零本地 ONNX 运行时）
+flatpak install https://xifan2333.github.io/flatpak-auto/refs/org.fcitx.Fcitx5.Addon.Vinput.Lite.flatpakref
 ```
 
 安装后需要授予额外权限并重启 Fcitx5：
@@ -138,7 +153,7 @@ flatpak kill org.fcitx.Fcitx5
 
 ## 本地安装
 
-下载对应发行版的安装包，直接安装。
+下载对应发行版的安装包，直接安装。支持**完整版**（带离线 sherpa-onnx 运行时）与 **Lite 极简版**（纯云端 ASR + LLM）。
 
 <ReleaseDownloads lang="zh-cn" />
 
@@ -148,10 +163,13 @@ flatpak kill org.fcitx.Fcitx5
 - **`.rpm`**：`sudo dnf install <文件>.rpm`
 - **`.pkg.tar.zst`**：`sudo pacman -U <文件>.pkg.tar.zst`
 - **`.flatpak`**：`flatpak install <文件>.flatpak`
+- **`.tar.gz`**：解压并按照内置说明运行安装
 
 ## 源码构建
 
 **依赖：** cmake、fcitx5、pipewire、libcurl、nlohmann-json、CLI11、Qt6
+
+### 完整版（带本地 sherpa-onnx 离线推理引擎）
 
 ```bash
 sudo bash scripts/build-sherpa-onnx.sh
@@ -170,5 +188,13 @@ sudo mise run install
 ```
 
 第一步会下载本地构建和发布打包所需的预编译 sherpa-onnx 运行时。运行时库随安装产物一起捆绑，不需要单独安装系统包依赖。
+
+### 极简 Lite 版（纯云端 ASR + LLM，零 sherpa-onnx 依赖）
+
+```bash
+cmake --preset release-clang-mold -DVINPUT_ENABLE_LOCAL_ASR=OFF
+cmake --build --preset release-clang-mold
+sudo cmake --install build
+```
 
 源码构建默认使用 Fcitx5 系统前缀（`/usr`），插件会安装到 Fcitx5 扫描的目录下。


### PR DESCRIPTION
Closes #138

### Implementation Tasks
- [x] 1. Update README.md and README_zh.md for all platform lite packages
- [x] 2. Update Astro documentation site install pages (en and zh-cn)
- [x] 3. Update ReleaseDownloads.astro asset categorization for lite packages