### PR TITLE
fix(addon): align default key initializers and tooltip in vinput.h and vinput_config.cpp (#141)

### DIFF
--- a/po/fcitx5-vinput.pot
+++ b/po/fcitx5-vinput.pot
@@ -948,7 +948,7 @@ msgstr ""
 
 msgid ""
 "Configure one or more keys to open the postprocess menu. The default is "
-"Right Alt + Control."
+"Right Shift."
 msgstr ""
 
 msgid "ASR Menu Keys"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -965,8 +965,8 @@ msgstr "后处理选单键"
 
 msgid ""
 "Configure one or more keys to open the postprocess menu. The default is "
-"Right Alt + Control."
-msgstr "可配置多个按键，用于打开后处理选单。默认是右 Alt + Ctrl。"
+"Right Shift."
+msgstr "可配置多个按键，用于打开后处理选单。默认是右 Shift。"
 
 msgid "ASR Menu Keys"
 msgstr "语音识别菜单键"

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -136,9 +136,9 @@ private:
   fcitx::InputContext* scene_menu_ic_ = nullptr;
   fcitx::InputContext* asr_menu_ic_ = nullptr;
   fcitx::InputContext* result_menu_ic_ = nullptr;
-  fcitx::KeyList trigger_keys_{fcitx::Key(FcitxKey_Control_R)};
-  fcitx::KeyList command_keys_{fcitx::Key(FcitxKey_F10)};
-  fcitx::KeyList scene_menu_key_{fcitx::Key(FcitxKey_F9)};
+  fcitx::KeyList trigger_keys_{fcitx::Key(FcitxKey_Alt_R)};
+  fcitx::KeyList command_keys_{fcitx::Key(FcitxKey_Control_R)};
+  fcitx::KeyList scene_menu_key_{fcitx::Key(FcitxKey_Shift_R)};
   fcitx::KeyList asr_menu_key_{fcitx::Key(FcitxKey_F8)};
   fcitx::KeyList page_prev_keys_{
       fcitx::Key(FcitxKey_Page_Up),

--- a/src/common/config/vinput_config.cpp
+++ b/src/common/config/vinput_config.cpp
@@ -61,7 +61,7 @@ std::string SceneMenuKeyLabel() {
 
 std::string SceneMenuKeyTooltip() {
   return _("Configure one or more keys to open the postprocess menu. The "
-           "default is Right Alt + Control.");
+           "default is Right Shift.");
 }
 
 std::string AsrMenuKeyLabel() {


### PR DESCRIPTION
Closes #141

### Implementation Tasks
- [x] 1. Align default key initializers in src/addon/core/vinput.h with VinputConfig
- [x] 2. Fix outdated tooltip text in src/common/config/vinput_config.cpp and update po files
- [x] 3. Run quality gate and translation checks