### PR TITLE
fix(addon): include <fcitx-utils/key.h> in vinput.h for misc-include-cleaner

### DIFF
--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -5,6 +5,7 @@
 #include <fcitx-utils/dbus/bus.h>
 #include <fcitx-utils/eventdispatcher.h>
 #include <fcitx-utils/handlertable.h>
+#include <fcitx-utils/key.h>
 #include <fcitx-utils/trackableobject.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>


### PR DESCRIPTION
Directly include `<fcitx-utils/key.h>` in `vinput.h` to satisfy clang-tidy `misc-include-cleaner`.