### PR TITLE
feat: manage adapter start/stop and daemon autostart in control page and CLI (#147)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__/
 fcitx5-vinput.flatpak
 node_modules/
 .astro/
+.pi/

--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -1,23 +1,23 @@
 # bash completion for vinput
 
 _vinput_installed_models() {
-    vinput model list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
+    vinput -j model list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
 }
 
 _vinput_installed_scenes() {
-    vinput scene list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
+    vinput -j scene list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
 }
 
 _vinput_installed_providers() {
-    vinput provider list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
+    vinput -j provider list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
 }
 
 _vinput_installed_llm_providers() {
-    vinput llm list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
+    vinput -j llm list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
 }
 
 _vinput_installed_adapters() {
-    vinput adapter list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
+    vinput -j adapter list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
 }
 
 _vinput() {

--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -16,6 +16,10 @@ _vinput_installed_llm_providers() {
     vinput llm list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
 }
 
+_vinput_installed_adapters() {
+    vinput adapter list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4
+}
+
 _vinput() {
     local cur prev words cword
     if declare -F _init_completion >/dev/null 2>&1; then
@@ -121,12 +125,19 @@ _vinput() {
                 if [[ "$cur" == -* ]]; then
                     COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
                 else
-                    COMPREPLY=($(compgen -W "list ls add start stop" -- "$cur"))
+                    COMPREPLY=($(compgen -W "list ls ps status add start stop restart enable disable" -- "$cur"))
                 fi
             else
                 case "${words[2]}" in
                     list|ls)
                         COMPREPLY=($(compgen -W "-a --available -h --help" -- "$cur"))
+                        ;;
+                    start|stop|restart|enable|disable|status)
+                        if [[ "$cur" == -* ]]; then
+                            COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
+                        else
+                            COMPREPLY=($(compgen -W "$(_vinput_installed_adapters)" -- "$cur"))
+                        fi
                         ;;
                 esac
             fi

--- a/data/completions/fish/vinput.fish
+++ b/data/completions/fish/vinput.fish
@@ -16,6 +16,10 @@ function __fish_vinput_installed_llm_providers
     vinput llm list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
 end
 
+function __fish_vinput_installed_adapters
+    vinput adapter list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
+end
+
 # Disable default file completions
 complete -c vinput -f
 
@@ -71,11 +75,17 @@ complete -c vinput -n "__fish_seen_subcommand_from llm; and __fish_seen_subcomma
 complete -c vinput -n "__fish_seen_subcommand_from llm; and __fish_seen_subcommand_from edit e remove rm test" -a "(__fish_vinput_installed_llm_providers)"
 
 # adapter
-complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls add start stop" -a "list ls" -d "List local or remote adapters"
-complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls add start stop" -a add -d "Install an adapter"
-complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls add start stop" -a start -d "Start an adapter process"
-complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls add start stop" -a stop -d "Stop an adapter process"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a "list ls" -d "List local or remote adapters"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a ps -d "List adapter processes and status"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a status -d "Show adapter status"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a add -d "Install an adapter"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a start -d "Start an adapter process"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a stop -d "Stop an adapter process"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a restart -d "Restart an adapter process"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a enable -d "Enable adapter autostart with daemon"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and not __fish_seen_subcommand_from list ls ps status add start stop restart enable disable" -a disable -d "Disable adapter autostart with daemon"
 complete -c vinput -n "__fish_seen_subcommand_from adapter; and __fish_seen_subcommand_from list ls" -s a -l available -d "List remote adapters"
+complete -c vinput -n "__fish_seen_subcommand_from adapter; and __fish_seen_subcommand_from start stop restart enable disable status" -a "(__fish_vinput_installed_adapters)"
 
 # hotword
 complete -c vinput -n "__fish_seen_subcommand_from hotword; and not __fish_seen_subcommand_from get set clear edit e" -a get -d "Show configured hotword path"

--- a/data/completions/fish/vinput.fish
+++ b/data/completions/fish/vinput.fish
@@ -1,23 +1,23 @@
 # fish completion for vinput
 
 function __fish_vinput_installed_models
-    vinput model list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
+    vinput -j model list 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
 end
 
 function __fish_vinput_installed_scenes
-    vinput scene list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
+    vinput -j scene list 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
 end
 
 function __fish_vinput_installed_providers
-    vinput provider list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
+    vinput -j provider list 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
 end
 
 function __fish_vinput_installed_llm_providers
-    vinput llm list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
+    vinput -j llm list 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
 end
 
 function __fish_vinput_installed_adapters
-    vinput adapter list -j 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
+    vinput -j adapter list 2>/dev/null | string match -r '"id":\s*"([^"]+)"' | string replace -r '"id":\s*"([^"]+)"' '$1'
 end
 
 # Disable default file completions

--- a/data/completions/zsh/_vinput
+++ b/data/completions/zsh/_vinput
@@ -24,6 +24,12 @@ _vinput_installed_llm_providers() {
     _describe -t llm_providers 'configured llm provider' llm_providers
 }
 
+_vinput_installed_adapters() {
+    local -a adapters
+    adapters=(${(f)"$(vinput adapter list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
+    _describe -t adapters 'configured adapter' adapters
+}
+
 _vinput_subcommands() {
     local -a subcommands
     subcommands=(
@@ -92,9 +98,14 @@ _vinput_adapter_cmds() {
     adapter_cmds=(
         'list:List local or remote adapters'
         'ls:List local or remote adapters'
+        'ps:List adapter processes and runtime status'
+        'status:Show adapter status'
         'add:Install an adapter script'
         'start:Start an adapter process'
         'stop:Stop an adapter process'
+        'restart:Restart an adapter process'
+        'enable:Enable adapter autostart with daemon'
+        'disable:Disable adapter autostart with daemon'
     )
     _describe -t adapter_cmds 'adapter command' adapter_cmds
 }
@@ -267,6 +278,10 @@ _vinput() {
                                     _arguments \
                                         '(-h --help)'{-h,--help}'[Print help message and exit]' \
                                         '(-a --available)'{-a,--available}'[List remote adapters]' ;;
+                                start|stop|restart|enable|disable|status)
+                                    _arguments \
+                                        '(-h --help)'{-h,--help}'[Print help message and exit]' \
+                                        '1:adapter:_vinput_installed_adapters' ;;
                             esac
                             ;;
                     esac

--- a/data/completions/zsh/_vinput
+++ b/data/completions/zsh/_vinput
@@ -2,32 +2,42 @@
 
 _vinput_installed_models() {
     local -a models
-    models=(${(f)"$(vinput model list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
-    _describe -t models 'installed model' models
+    models=(${(f)"$(vinput -j model list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
+    if (( $#models )); then
+        _describe -t models 'installed model' models
+    fi
 }
 
 _vinput_installed_scenes() {
     local -a scenes
-    scenes=(${(f)"$(vinput scene list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
-    _describe -t scenes 'installed scene' scenes
+    scenes=(${(f)"$(vinput -j scene list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
+    if (( $#scenes )); then
+        _describe -t scenes 'installed scene' scenes
+    fi
 }
 
 _vinput_installed_providers() {
     local -a providers
-    providers=(${(f)"$(vinput provider list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
-    _describe -t providers 'installed provider' providers
+    providers=(${(f)"$(vinput -j provider list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
+    if (( $#providers )); then
+        _describe -t providers 'installed provider' providers
+    fi
 }
 
 _vinput_installed_llm_providers() {
     local -a llm_providers
-    llm_providers=(${(f)"$(vinput llm list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
-    _describe -t llm_providers 'configured llm provider' llm_providers
+    llm_providers=(${(f)"$(vinput -j llm list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
+    if (( $#llm_providers )); then
+        _describe -t llm_providers 'configured llm provider' llm_providers
+    fi
 }
 
 _vinput_installed_adapters() {
     local -a adapters
-    adapters=(${(f)"$(vinput adapter list -j 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
-    _describe -t adapters 'configured adapter' adapters
+    adapters=(${(f)"$(vinput -j adapter list 2>/dev/null | grep -o '"id": *"[^"]*"' | cut -d'"' -f4)"})
+    if (( $#adapters )); then
+        _describe -t adapters 'configured adapter' adapters
+    fi
 }
 
 _vinput_subcommands() {
@@ -400,6 +410,8 @@ _vinput() {
     esac
 }
 
-if [[ -n "$CURRENT" ]]; then
+if [[ -n "$compstate[context]" ]]; then
     _vinput "$@"
+else
+    compdef _vinput vinput 2>/dev/null || true
 fi

--- a/data/man/en/vinput-config.5
+++ b/data/man/en/vinput-config.5
@@ -82,9 +82,21 @@ Defines OpenAI\-compatible API endpoints.
       \(dqapi_key\(dq: \(dqYOUR_API_KEY\(dq,
       \(dqextra_body\(dq: {}
     }
+  ],
+  \(dqadapters\(dq: [
+    {
+      \(dqid\(dq: \(dqmy\-adapter\(dq,
+      \(dqcommand\(dq: \(dqpython3\(dq,
+      \(dqargs\(dq: [\(dq/path/to/entry.py\(dq],
+      \(dqauto_start\(dq: \f[B]true\f[R]
+    }
   ]
 }
 .EE
+.TP
+\f[B]adapters[].auto_start\f[R] (\f[I]boolean\f[R])
+Whether to automatically launch the adapter process when
+\f[B]vinput\-daemon\f[R] starts.
 .SS SCENES SECTION
 Defines prompt templates and candidate counts for text rewriting.
 .IP

--- a/data/man/en/vinput-config.5.md
+++ b/data/man/en/vinput-config.5.md
@@ -85,9 +85,20 @@ Defines OpenAI-compatible API endpoints.
       "api_key": "YOUR_API_KEY",
       "extra_body": {}
     }
+  ],
+  "adapters": [
+    {
+      "id": "my-adapter",
+      "command": "python3",
+      "args": ["/path/to/entry.py"],
+      "auto_start": true
+    }
   ]
 }
 ```
+
+**adapters[].auto_start** (*boolean*)
+:   Whether to automatically launch the adapter process when **vinput-daemon** starts.
 
 ## SCENES SECTION
 Defines prompt templates and candidate counts for text rewriting.

--- a/data/man/en/vinput.1
+++ b/data/man/en/vinput.1
@@ -97,7 +97,15 @@ Manage local bridge processes that adapt non\-standard models into
 OpenAI\-compatible endpoints.
 .TP
 \f[B]adapter list\f[R] [\f[B]\-a\f[R], \f[B]\-\-available\f[R]]
-List local adapters, or available remote adapters with \f[B]\-a\f[R].
+List local adapters with autostart status, or available remote adapters
+with \f[B]\-a\f[R].
+.TP
+\f[B]adapter ps\f[R]
+List adapter processes and runtime status (status, PID, autostart, and
+command).
+.TP
+\f[B]adapter status\f[R] \f[I]ID\f[R]
+Show detailed status and configuration properties for an adapter.
 .TP
 \f[B]adapter add\f[R] \f[I]ID\f[R]
 Install an adapter script by \f[I]ID\f[R].
@@ -107,6 +115,15 @@ Start the background adapter process.
 .TP
 \f[B]adapter stop\f[R] \f[I]ID\f[R]
 Stop the running adapter process.
+.TP
+\f[B]adapter restart\f[R] \f[I]ID\f[R]
+Restart the specified adapter process.
+.TP
+\f[B]adapter enable\f[R] \f[I]ID\f[R]
+Enable the adapter to autostart when the daemon starts.
+.TP
+\f[B]adapter disable\f[R] \f[I]ID\f[R]
+Disable the adapter from autostarting with the daemon.
 .SS HOTWORD MANAGEMENT
 Manage domain\-specific vocabulary and custom dictionaries for local
 sherpa\-onnx models.

--- a/data/man/en/vinput.1.md
+++ b/data/man/en/vinput.1.md
@@ -91,7 +91,13 @@ Manage OpenAI-compatible LLM endpoints for scene post-processing and text rewrit
 Manage local bridge processes that adapt non-standard models into OpenAI-compatible endpoints.
 
 **adapter list** [**-a**, **--available**]
-:   List local adapters, or available remote adapters with **-a**.
+:   List local adapters with autostart status, or available remote adapters with **-a**.
+
+**adapter ps**
+:   List adapter processes and runtime status (status, PID, autostart, and command).
+
+**adapter status** *ID*
+:   Show detailed status and configuration properties for an adapter.
 
 **adapter add** *ID*
 :   Install an adapter script by *ID*.
@@ -101,6 +107,15 @@ Manage local bridge processes that adapt non-standard models into OpenAI-compati
 
 **adapter stop** *ID*
 :   Stop the running adapter process.
+
+**adapter restart** *ID*
+:   Restart the specified adapter process.
+
+**adapter enable** *ID*
+:   Enable the adapter to autostart when the daemon starts.
+
+**adapter disable** *ID*
+:   Disable the adapter from autostarting with the daemon.
 
 ## HOTWORD MANAGEMENT
 Manage domain-specific vocabulary and custom dictionaries for local sherpa-onnx models.

--- a/data/man/zh_CN/vinput-config.5
+++ b/data/man/zh_CN/vinput-config.5
@@ -81,9 +81,20 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
       \(dqapi_key\(dq: \(dqYOUR_API_KEY\(dq,
       \(dqextra_body\(dq: {}
     }
+  ],
+  \(dqadapters\(dq: [
+    {
+      \(dqid\(dq: \(dqmy\-adapter\(dq,
+      \(dqcommand\(dq: \(dqpython3\(dq,
+      \(dqargs\(dq: [\(dq/path/to/entry.py\(dq],
+      \(dqauto_start\(dq: \f[B]true\f[R]
+    }
   ]
 }
 .EE
+.TP
+\f[B]adapters[].auto_start\f[R] (\f[I]布尔值\f[R])
+是否在 \f[B]vinput\-daemon\f[R] 启动时自动启动该适配器进程。
 .SS SCENES 场景后处理配置
 定义用于文字润色、错别字修正或翻译的提示词模板与候选词配置。
 .IP

--- a/data/man/zh_CN/vinput-config.5.md
+++ b/data/man/zh_CN/vinput-config.5.md
@@ -85,9 +85,20 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
       "api_key": "YOUR_API_KEY",
       "extra_body": {}
     }
+  ],
+  "adapters": [
+    {
+      "id": "my-adapter",
+      "command": "python3",
+      "args": ["/path/to/entry.py"],
+      "auto_start": true
+    }
   ]
 }
 ```
+
+**adapters[].auto_start** (*布尔值*)
+:   是否在 **vinput-daemon** 启动时自动启动该适配器进程。
 
 ## SCENES 场景后处理配置
 定义用于文字润色、错别字修正或翻译的提示词模板与候选词配置。

--- a/data/man/zh_CN/vinput.1
+++ b/data/man/zh_CN/vinput.1
@@ -89,7 +89,14 @@ Key（可选）及额外的请求体参数（可选）。
 管理将非标准本地模型封装为 OpenAI 兼容接口的本地桥接适配进程。
 .TP
 \f[B]adapter list\f[R] [\f[B]\-a\f[R], \f[B]\-\-available\f[R]]
-列出本地适配器；使用 \f[B]\-a\f[R] 浏览在线注册表中的可用适配器。
+列出本地适配器（显示自启动状态）；使用 \f[B]\-a\f[R]
+浏览在线注册表中的可用适配器。
+.TP
+\f[B]adapter ps\f[R]
+列出适配器进程与运行时状态（包括运行状态、PID、自启动策略与启动命令）。
+.TP
+\f[B]adapter status\f[R] \f[I]ID\f[R]
+查看指定适配器的详细运行状态与配置属性。
 .TP
 \f[B]adapter add\f[R] \f[I]ID\f[R]
 安装指定 \f[I]ID\f[R] 的适配器脚本。
@@ -99,6 +106,15 @@ Key（可选）及额外的请求体参数（可选）。
 .TP
 \f[B]adapter stop\f[R] \f[I]ID\f[R]
 停止正在运行的适配器进程。
+.TP
+\f[B]adapter restart\f[R] \f[I]ID\f[R]
+重启指定的适配器进程。
+.TP
+\f[B]adapter enable\f[R] \f[I]ID\f[R]
+将指定适配器设置为随守护进程自启动。
+.TP
+\f[B]adapter disable\f[R] \f[I]ID\f[R]
+取消指定适配器随守护进程自启动。
 .SS 热词表管理
 管理用于增强离线 sherpa\-onnx 模型专有名词识别准确率的自定义词表。
 .TP

--- a/data/man/zh_CN/vinput.1.md
+++ b/data/man/zh_CN/vinput.1.md
@@ -91,7 +91,13 @@ vinput - fcitx5-vinput 命令行控制与管理工具
 管理将非标准本地模型封装为 OpenAI 兼容接口的本地桥接适配进程。
 
 **adapter list** [**-a**, **--available**]
-:   列出本地适配器；使用 **-a** 浏览在线注册表中的可用适配器。
+:   列出本地适配器（显示自启动状态）；使用 **-a** 浏览在线注册表中的可用适配器。
+
+**adapter ps**
+:   列出适配器进程与运行时状态（包括运行状态、PID、自启动策略与启动命令）。
+
+**adapter status** *ID*
+:   查看指定适配器的详细运行状态与配置属性。
 
 **adapter add** *ID*
 :   安装指定 *ID* 的适配器脚本。
@@ -101,6 +107,15 @@ vinput - fcitx5-vinput 命令行控制与管理工具
 
 **adapter stop** *ID*
 :   停止正在运行的适配器进程。
+
+**adapter restart** *ID*
+:   重启指定的适配器进程。
+
+**adapter enable** *ID*
+:   将指定适配器设置为随守护进程自启动。
+
+**adapter disable** *ID*
+:   取消指定适配器随守护进程自启动。
 
 ## 热词表管理
 管理用于增强离线 sherpa-onnx 模型专有名词识别准确率的自定义词表。

--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -51,6 +51,10 @@
         <source>Details</source>
         <translation>查看详情</translation>
     </message>
+    <message>
+        <source>Start with daemon</source>
+        <translation>随守护进程启动</translation>
+    </message>
 </context>
 <context>
     <name>vinput::gui::ControlPage</name>
@@ -222,6 +226,38 @@
         <source>The local ASR provider cannot be removed.</source>
         <translation>内置的本地语音识别不可移除。</translation>
     </message>
+    <message>
+        <source>&lt;b&gt;Adapters&lt;/b&gt;</source>
+        <translation>&lt;b&gt;适配器&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Start with daemon</source>
+        <translation>随守护进程启动</translation>
+    </message>
+    <message>
+        <source>Automatically start this adapter when vinput-daemon starts.</source>
+        <translation>当 vinput-daemon 启动时自动启动此适配器。</translation>
+    </message>
+    <message>
+        <source>autostart</source>
+        <translation>自启动</translation>
+    </message>
+    <message>
+        <source>manual</source>
+        <translation>手动</translation>
+    </message>
+    <message>
+        <source>Command: %1</source>
+        <translation>命令：%1</translation>
+    </message>
+    <message>
+        <source>Args: %1</source>
+        <translation>参数：%1</translation>
+    </message>
+    <message>
+        <source>Env: %1</source>
+        <translation>环境变量：%1</translation>
+    </message>
 </context>
 <context>
     <name>vinput::gui::HotwordPage</name>
@@ -367,6 +403,26 @@
     <message>
         <source>Edit Scene</source>
         <translation>编辑场景</translation>
+    </message>
+    <message>
+        <source>autostart</source>
+        <translation>自启动</translation>
+    </message>
+    <message>
+        <source>manual</source>
+        <translation>手动</translation>
+    </message>
+    <message>
+        <source>Autostart: %1</source>
+        <translation>自启动：%1</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <translation>已启用</translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <translation>已禁用</translation>
     </message>
     <message>
         <source>ID:</source>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1129,3 +1129,16 @@ msgstr "运行中"
 
 msgid "stopped"
 msgstr "已停止"
+
+msgid "Restart an adapter"
+msgstr "重启适配器"
+
+msgid "Enable adapter autostart with daemon"
+msgstr "启用适配器随 daemon 自启动"
+
+msgid "Disable adapter autostart with daemon"
+msgstr "禁用适配器随 daemon 自启动"
+
+#, c-format
+msgid "Adapter '%s' restarted."
+msgstr "Adapter '%s' 已重启。"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1088,35 +1088,46 @@ msgid "AUTOSTART"
 msgstr "自启动"
 
 #, c-format
-msgid "Adapter '%s' daemon autostart is %s."
-msgstr "适配器 '%s' 随 daemon 自启动状态为：%s。"
-
-#, c-format
-msgid "Adapter '%s' daemon autostart set to %s."
-msgstr "已将适配器 '%s' 随 daemon 自启动设置为：%s。"
-
-#, c-format
 msgid "Adapter '%s' not found."
 msgstr "未找到适配器 '%s'。"
 
-msgid "Cannot specify both --enable and --disable."
-msgstr "不能同时指定 --enable 和 --disable。"
+msgid "List adapter processes and runtime status"
+msgstr "列出适配器进程与运行状态"
 
-msgid "Configure or show adapter autostart with daemon"
-msgstr "配置或查看适配器是否随 daemon 自启动"
-
-msgid "Disable autostart with daemon"
-msgstr "禁用随 daemon 自启动"
-
-msgid "Enable autostart with daemon"
-msgstr "启用随 daemon 自启动"
+msgid "Show adapter status"
+msgstr "显示适配器状态"
 
 #, c-format
-msgid "Invalid autostart state '%s'. Use on/off, true/false, enable/disable."
-msgstr "无效的自启动状态 '%s'。请使用 on/off、true/false 或 enable/disable。"
+msgid "Adapter '%s' enabled to autostart with daemon."
+msgstr "已启用适配器 '%s' 随 daemon 自启动。"
 
-msgid "Target autostart state (on/off, enable/disable)"
-msgstr "目标自启动状态（on/off，enable/disable）"
+#, c-format
+msgid "Adapter '%s' disabled from autostart with daemon."
+msgstr "已禁用适配器 '%s' 随 daemon 自启动。"
+
+msgid "PID"
+msgstr "PID"
+
+msgid "COMMAND"
+msgstr "命令"
+
+msgid "PROPERTY"
+msgstr "属性"
+
+msgid "VALUE"
+msgstr "值"
+
+msgid "Title"
+msgstr "名称"
+
+msgid "Status"
+msgstr "状态"
+
+msgid "Autostart"
+msgstr "自启动"
+
+msgid "Args"
+msgstr "参数"
 
 msgid "disabled"
 msgstr "已禁用"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1114,9 +1114,6 @@ msgstr "命令"
 msgid "PROPERTY"
 msgstr "属性"
 
-msgid "VALUE"
-msgstr "值"
-
 msgid "Title"
 msgstr "名称"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1083,3 +1083,49 @@ msgstr "流式识别最大显示列宽"
 
 msgid "Maximum visual column width for live streaming recognition preview. Older text is folded into 'head...tail'. Set to 0 to disable folding. Default is 60."
 msgstr "实时流式识别预览的最大视觉显示列宽。较早的内容会被折叠为“句首...句尾”。设为 0 则禁用折叠。默认值为 60。"
+
+msgid "AUTOSTART"
+msgstr "自启动"
+
+#, c-format
+msgid "Adapter '%s' daemon autostart is %s."
+msgstr "适配器 '%s' 随 daemon 自启动状态为：%s。"
+
+#, c-format
+msgid "Adapter '%s' daemon autostart set to %s."
+msgstr "已将适配器 '%s' 随 daemon 自启动设置为：%s。"
+
+#, c-format
+msgid "Adapter '%s' not found."
+msgstr "未找到适配器 '%s'。"
+
+msgid "Cannot specify both --enable and --disable."
+msgstr "不能同时指定 --enable 和 --disable。"
+
+msgid "Configure or show adapter autostart with daemon"
+msgstr "配置或查看适配器是否随 daemon 自启动"
+
+msgid "Disable autostart with daemon"
+msgstr "禁用随 daemon 自启动"
+
+msgid "Enable autostart with daemon"
+msgstr "启用随 daemon 自启动"
+
+#, c-format
+msgid "Invalid autostart state '%s'. Use on/off, true/false, enable/disable."
+msgstr "无效的自启动状态 '%s'。请使用 on/off、true/false 或 enable/disable。"
+
+msgid "Target autostart state (on/off, enable/disable)"
+msgstr "目标自启动状态（on/off，enable/disable）"
+
+msgid "disabled"
+msgstr "已禁用"
+
+msgid "enabled"
+msgstr "已启用"
+
+msgid "running"
+msgstr "运行中"
+
+msgid "stopped"
+msgstr "已停止"

--- a/site/src/content/docs/scenes/index.md
+++ b/site/src/content/docs/scenes/index.md
@@ -155,15 +155,21 @@ Corresponding config:
 ### GUI
 
 In Vinput GUI, go to **Resources → LLM Adapters** to browse and install.
+Manage adapter start/stop and autostart with daemon on the **Control** page.
 
 ### CLI
 
 ```bash
-vinput adapter list             # List installed adapters
+vinput adapter ls               # List installed adapters with autostart policy
 vinput adapter list -a          # List available remote adapters
-vinput adapter add <id>         # Install
-vinput adapter start <id>       # Start
-vinput adapter stop <id>        # Stop
+vinput adapter ps               # View adapter processes and runtime PID status
+vinput adapter status <id>      # Show detailed status for a specific adapter
+vinput adapter add <id>         # Install an adapter
+vinput adapter start <id>       # Start adapter process
+vinput adapter stop <id>        # Stop adapter process
+vinput adapter restart <id>     # Restart adapter process
+vinput adapter enable <id>      # Enable autostart with daemon
+vinput adapter disable <id>     # Disable autostart with daemon
 ```
 
 ## Command mode

--- a/site/src/content/docs/zh-cn/scenes/index.md
+++ b/site/src/content/docs/zh-cn/scenes/index.md
@@ -155,15 +155,21 @@ vinput llm remove <id>                  # 删除
 ### GUI 操作
 
 在 Vinput GUI 中进入 **资源 → LLM 适配器**，浏览并安装。
+在 **控制** 页面中管理适配器的启动、停止与是否伴随守护进程自启动。
 
 ### CLI 操作
 
 ```bash
-vinput adapter list             # 列出已安装适配器
-vinput adapter list -a          # 列出可用远程适配器
-vinput adapter add <id>         # 安装
-vinput adapter start <id>       # 启动
-vinput adapter stop <id>        # 停止
+vinput adapter ls               # 列出已安装适配器及自启策略
+vinput adapter list -a          # 浏览可用远程适配器
+vinput adapter ps               # 查看适配器进程运行状态与 PID
+vinput adapter status <id>      # 查看指定适配器的详细状态
+vinput adapter add <id>         # 安装适配器
+vinput adapter start <id>       # 启动适配器进程
+vinput adapter stop <id>        # 停止适配器进程
+vinput adapter restart <id>     # 重启适配器进程
+vinput adapter enable <id>      # 设为随 daemon 自启动
+vinput adapter disable <id>     # 取消随 daemon 自启动
 ```
 
 ## 命令模式

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -47,9 +47,7 @@ int SetAdapterAutostart(const std::string& id, bool enable, Formatter& fmt, cons
   }
 
   if (ctx.json_output) {
-    // NOLINTNEXTLINE(misc-include-cleaner)
-    const nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
-    fmt.PrintJson(j);
+    fmt.PrintJson({{"id", resolved_id}, {"auto_start", it->autoStart}});
     return 0;
   }
 
@@ -438,7 +436,7 @@ int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliCo
   const bool running = (pid > 0);
 
   if (ctx.json_output) {
-    const nlohmann::json j = {
+    fmt.PrintJson({
         {"id", vinput::cli::HumanizeResourceId(installed_display_map, adapter->id)},
         {"machine_id", adapter->id},
         {"title", title},
@@ -449,8 +447,7 @@ int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliCo
         {"command", adapter->command},
         {"args", adapter->args},
         {"env", adapter->env},
-    };
-    fmt.PrintJson(j);
+    });
     return 0;
   }
 

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -93,20 +93,24 @@ int RunLlmConfigListAdapters(bool available, Formatter& fmt, const CliContext& c
             {"args", adapter.args},
             {"env", adapter.env},
             {"running", vinput::adapter::IsRunning(adapter.id)},
+            {"auto_start", adapter.autoStart},
         });
       }
       fmt.PrintJson(arr);
       return 0;
     }
 
-    std::vector<std::string> headers = {_("ID"), _("TITLE"), _("README")};
+    std::vector<std::string> headers = {_("ID"), _("TITLE"), _("STATUS"), _("AUTOSTART"),
+                                        _("README")};
     std::vector<std::vector<std::string>> rows;
     rows.reserve(config.llm.adapters.size());
     for (const auto& adapter : config.llm.adapters) {
       const bool has_entry = installed_display_map.contains(adapter.id);
+      const bool running = vinput::adapter::IsRunning(adapter.id);
       rows.push_back(
           {vinput::cli::HumanizeResourceId(installed_display_map, adapter.id),
            has_entry ? installed_display_map.at(adapter.id).title : "",
+           running ? _("running") : _("stopped"), adapter.autoStart ? _("enabled") : _("disabled"),
            has_entry ? vinput::cli::FormatTerminalLink(
                            ctx, _("Open README"), installed_display_map.at(adapter.id).readme_url)
                      : ""});
@@ -288,6 +292,84 @@ int RunLlmConfigStopAdapter(const std::string& id, Formatter& fmt, const CliCont
     return 1;
   }
   fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' stopped."), id));
+  return 0;
+}
+
+int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state, bool enable,
+                                 bool disable, Formatter& fmt, const CliContext& ctx) {
+  if (enable && disable) {
+    fmt.PrintError(_("Cannot specify both --enable and --disable."));
+    return 1;
+  }
+
+  CoreConfig config = LoadCoreConfig();
+  std::string error;
+  const std::string resolved_id =
+      vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
+  if (resolved_id.empty()) {
+    fmt.PrintError(error);
+    return 1;
+  }
+
+  auto it = std::find_if(config.llm.adapters.begin(), config.llm.adapters.end(),
+                         [&resolved_id](const LlmAdapter& a) { return a.id == resolved_id; });
+  if (it == config.llm.adapters.end()) {
+    fmt.PrintError(vinput::str::FmtStr(_("Adapter '%s' not found."), id));
+    return 1;
+  }
+
+  bool has_target = false;
+  bool target_state = false;
+  if (enable) {
+    has_target = true;
+    target_state = true;
+  } else if (disable) {
+    has_target = true;
+    target_state = false;
+  } else if (!state.empty()) {
+    std::string lower_state = state;
+    std::transform(lower_state.begin(), lower_state.end(), lower_state.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower_state == "on" || lower_state == "true" || lower_state == "1" ||
+        lower_state == "enable" || lower_state == "enabled") {
+      has_target = true;
+      target_state = true;
+    } else if (lower_state == "off" || lower_state == "false" || lower_state == "0" ||
+               lower_state == "disable" || lower_state == "disabled") {
+      has_target = true;
+      target_state = false;
+    } else {
+      fmt.PrintError(vinput::str::FmtStr(
+          _("Invalid autostart state '%s'. Use on/off, true/false, enable/disable."), state));
+      return 1;
+    }
+  }
+
+  if (!has_target) {
+    if (ctx.json_output) {
+      nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
+      fmt.PrintJson(j);
+      return 0;
+    }
+    fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' daemon autostart is %s."), id,
+                                         it->autoStart ? _("enabled") : _("disabled")));
+    return 0;
+  }
+
+  it->autoStart = target_state;
+  NormalizeCoreConfig(&config);
+  if (!SaveConfigOrFail(config, fmt)) {
+    return 1;
+  }
+
+  if (ctx.json_output) {
+    nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
+    fmt.PrintJson(j);
+    return 0;
+  }
+
+  fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' daemon autostart set to %s."), id,
+                                       it->autoStart ? _("enabled") : _("disabled")));
   return 0;
 }
 

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -295,6 +295,41 @@ int RunLlmConfigStopAdapter(const std::string& id, Formatter& fmt, const CliCont
   return 0;
 }
 
+int RunLlmConfigRestartAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
+  (void)ctx;
+  CoreConfig config = LoadCoreConfig();
+  std::string error;
+  const std::string resolved_id =
+      vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
+  if (resolved_id.empty()) {
+    fmt.PrintError(error);
+    return 1;
+  }
+  vinput::cli::DbusClient dbus;
+  if (vinput::adapter::IsRunning(resolved_id)) {
+    if (!dbus.StopAdapter(resolved_id, &error)) {
+      fmt.PrintError(error);
+      return 1;
+    }
+  }
+  if (!dbus.StartAdapter(resolved_id, &error)) {
+    fmt.PrintError(error);
+    return 1;
+  }
+  fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' restarted."), id));
+  return 0;
+}
+
+int RunLlmConfigEnableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
+  return RunLlmConfigAutostartAdapter(id, /*state=*/"", /*enable=*/true, /*disable=*/false, fmt,
+                                      ctx);
+}
+
+int RunLlmConfigDisableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
+  return RunLlmConfigAutostartAdapter(id, /*state=*/"", /*enable=*/false, /*disable=*/true, fmt,
+                                      ctx);
+}
+
 int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state, bool enable,
                                  bool disable, Formatter& fmt, const CliContext& ctx) {
   if (enable && disable) {

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -1,8 +1,11 @@
 #include "cli/config/llm_actions.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <sys/types.h>
 
 #include "common/config/core_config.h"
 #include "common/i18n.h"
@@ -17,6 +20,44 @@
 #include "cli/utils/resource_utils.h"
 
 namespace {
+
+int SetAdapterAutostart(const std::string& id, bool enable, Formatter& fmt, const CliContext& ctx) {
+  CoreConfig config = LoadCoreConfig();
+  std::string error;
+  const std::string resolved_id =
+      vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
+  if (resolved_id.empty()) {
+    fmt.PrintError(error);
+    return 1;
+  }
+
+  auto it = std::find_if(config.llm.adapters.begin(), config.llm.adapters.end(),
+                         [&resolved_id](const LlmAdapter& a) { return a.id == resolved_id; });
+  if (it == config.llm.adapters.end()) {
+    fmt.PrintError(vinput::str::FmtStr(_("Adapter '%s' not found."), id));
+    return 1;
+  }
+
+  it->autoStart = enable;
+  NormalizeCoreConfig(&config);
+  if (!SaveConfigOrFail(config, fmt)) {
+    return 1;
+  }
+
+  if (ctx.json_output) {
+    const nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
+    fmt.PrintJson(j);
+    return 0;
+  }
+
+  if (enable) {
+    fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' enabled to autostart with daemon."), id));
+  } else {
+    fmt.PrintSuccess(
+        vinput::str::FmtStr(_("Adapter '%s' disabled from autostart with daemon."), id));
+  }
+  return 0;
+}
 
 std::string MaskApiKey(const std::string& key) {
   if (key.size() <= 8) {
@@ -99,7 +140,7 @@ int RunLlmConfigListAdapters(bool available, Formatter& fmt, const CliContext& c
       return 0;
     }
 
-    std::vector<std::string> headers = {_("ID"), _("TITLE"), _("AUTOSTART"), _("README")};
+    const std::vector<std::string> headers = {_("ID"), _("TITLE"), _("AUTOSTART"), _("README")};
     std::vector<std::vector<std::string>> rows;
     rows.reserve(config.llm.adapters.size());
     for (const auto& adapter : config.llm.adapters) {
@@ -294,7 +335,7 @@ int RunLlmConfigStopAdapter(const std::string& id, Formatter& fmt, const CliCont
 
 int RunLlmConfigRestartAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
   (void)ctx;
-  CoreConfig config = LoadCoreConfig();
+  const CoreConfig config = LoadCoreConfig();
   std::string error;
   const std::string resolved_id =
       vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
@@ -317,45 +358,6 @@ int RunLlmConfigRestartAdapter(const std::string& id, Formatter& fmt, const CliC
   return 0;
 }
 
-static int SetAdapterAutostart(const std::string& id, bool enable, Formatter& fmt,
-                               const CliContext& ctx) {
-  CoreConfig config = LoadCoreConfig();
-  std::string error;
-  const std::string resolved_id =
-      vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
-  if (resolved_id.empty()) {
-    fmt.PrintError(error);
-    return 1;
-  }
-
-  auto it = std::find_if(config.llm.adapters.begin(), config.llm.adapters.end(),
-                         [&resolved_id](const LlmAdapter& a) { return a.id == resolved_id; });
-  if (it == config.llm.adapters.end()) {
-    fmt.PrintError(vinput::str::FmtStr(_("Adapter '%s' not found."), id));
-    return 1;
-  }
-
-  it->autoStart = enable;
-  NormalizeCoreConfig(&config);
-  if (!SaveConfigOrFail(config, fmt)) {
-    return 1;
-  }
-
-  if (ctx.json_output) {
-    nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
-    fmt.PrintJson(j);
-    return 0;
-  }
-
-  if (enable) {
-    fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' enabled to autostart with daemon."), id));
-  } else {
-    fmt.PrintSuccess(
-        vinput::str::FmtStr(_("Adapter '%s' disabled from autostart with daemon."), id));
-  }
-  return 0;
-}
-
 int RunLlmConfigEnableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
   return SetAdapterAutostart(id, true, fmt, ctx);
 }
@@ -365,7 +367,7 @@ int RunLlmConfigDisableAdapter(const std::string& id, Formatter& fmt, const CliC
 }
 
 int RunLlmConfigPsAdapters(Formatter& fmt, const CliContext& ctx) {
-  CoreConfig config = LoadCoreConfig();
+  const CoreConfig config = LoadCoreConfig();
   const auto installed_display_map =
       vinput::cli::FetchScriptDisplayMap(config, vinput::script::Kind::kLlmAdapter);
 
@@ -390,7 +392,8 @@ int RunLlmConfigPsAdapters(Formatter& fmt, const CliContext& ctx) {
     return 0;
   }
 
-  std::vector<std::string> headers = {_("ID"), _("STATUS"), _("PID"), _("AUTOSTART"), _("COMMAND")};
+  const std::vector<std::string> headers = {_("ID"), _("STATUS"), _("PID"), _("AUTOSTART"),
+                                            _("COMMAND")};
   std::vector<std::vector<std::string>> rows;
   rows.reserve(config.llm.adapters.size());
   for (const auto& adapter : config.llm.adapters) {
@@ -409,7 +412,7 @@ int RunLlmConfigPsAdapters(Formatter& fmt, const CliContext& ctx) {
 }
 
 int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
-  CoreConfig config = LoadCoreConfig();
+  const CoreConfig config = LoadCoreConfig();
   std::string error;
   const std::string resolved_id =
       vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
@@ -419,7 +422,7 @@ int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliCo
   }
 
   const auto* adapter = ResolveLlmAdapter(config, resolved_id);
-  if (!adapter) {
+  if (adapter == nullptr) {
     fmt.PrintError(vinput::str::FmtStr(_("Adapter '%s' not found."), id));
     return 1;
   }
@@ -432,7 +435,7 @@ int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliCo
   const bool running = (pid > 0);
 
   if (ctx.json_output) {
-    nlohmann::json j = {
+    const nlohmann::json j = {
         {"id", vinput::cli::HumanizeResourceId(installed_display_map, adapter->id)},
         {"machine_id", adapter->id},
         {"title", title},
@@ -448,7 +451,7 @@ int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliCo
     return 0;
   }
 
-  std::vector<std::string> headers = {_("PROPERTY"), _("VALUE")};
+  const std::vector<std::string> headers = {_("PROPERTY"), _("VALUE")};
   std::vector<std::vector<std::string>> rows = {
       {_("ID"), vinput::cli::HumanizeResourceId(installed_display_map, adapter->id)},
       {_("Title"), title},
@@ -460,8 +463,9 @@ int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliCo
   if (!adapter->args.empty()) {
     std::string args_joined;
     for (size_t i = 0; i < adapter->args.size(); ++i) {
-      if (i > 0)
+      if (i > 0) {
         args_joined += " ";
+      }
       args_joined += adapter->args[i];
     }
     rows.push_back({_("Args"), args_joined});

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -100,17 +100,15 @@ int RunLlmConfigListAdapters(bool available, Formatter& fmt, const CliContext& c
       return 0;
     }
 
-    std::vector<std::string> headers = {_("ID"), _("TITLE"), _("STATUS"), _("AUTOSTART"),
-                                        _("README")};
+    std::vector<std::string> headers = {_("ID"), _("TITLE"), _("AUTOSTART"), _("README")};
     std::vector<std::vector<std::string>> rows;
     rows.reserve(config.llm.adapters.size());
     for (const auto& adapter : config.llm.adapters) {
       const bool has_entry = installed_display_map.contains(adapter.id);
-      const bool running = vinput::adapter::IsRunning(adapter.id);
       rows.push_back(
           {vinput::cli::HumanizeResourceId(installed_display_map, adapter.id),
            has_entry ? installed_display_map.at(adapter.id).title : "",
-           running ? _("running") : _("stopped"), adapter.autoStart ? _("enabled") : _("disabled"),
+           adapter.autoStart ? _("enabled") : _("disabled"),
            has_entry ? vinput::cli::FormatTerminalLink(
                            ctx, _("Open README"), installed_display_map.at(adapter.id).readme_url)
                      : ""});
@@ -320,23 +318,8 @@ int RunLlmConfigRestartAdapter(const std::string& id, Formatter& fmt, const CliC
   return 0;
 }
 
-int RunLlmConfigEnableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
-  return RunLlmConfigAutostartAdapter(id, /*state=*/"", /*enable=*/true, /*disable=*/false, fmt,
-                                      ctx);
-}
-
-int RunLlmConfigDisableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
-  return RunLlmConfigAutostartAdapter(id, /*state=*/"", /*enable=*/false, /*disable=*/true, fmt,
-                                      ctx);
-}
-
-int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state, bool enable,
-                                 bool disable, Formatter& fmt, const CliContext& ctx) {
-  if (enable && disable) {
-    fmt.PrintError(_("Cannot specify both --enable and --disable."));
-    return 1;
-  }
-
+static int SetAdapterAutostart(const std::string& id, bool enable, Formatter& fmt,
+                               const CliContext& ctx) {
   CoreConfig config = LoadCoreConfig();
   std::string error;
   const std::string resolved_id =
@@ -353,45 +336,7 @@ int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state
     return 1;
   }
 
-  bool has_target = false;
-  bool target_state = false;
-  if (enable) {
-    has_target = true;
-    target_state = true;
-  } else if (disable) {
-    has_target = true;
-    target_state = false;
-  } else if (!state.empty()) {
-    std::string lower_state = state;
-    std::transform(lower_state.begin(), lower_state.end(), lower_state.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    if (lower_state == "on" || lower_state == "true" || lower_state == "1" ||
-        lower_state == "enable" || lower_state == "enabled") {
-      has_target = true;
-      target_state = true;
-    } else if (lower_state == "off" || lower_state == "false" || lower_state == "0" ||
-               lower_state == "disable" || lower_state == "disabled") {
-      has_target = true;
-      target_state = false;
-    } else {
-      fmt.PrintError(vinput::str::FmtStr(
-          _("Invalid autostart state '%s'. Use on/off, true/false, enable/disable."), state));
-      return 1;
-    }
-  }
-
-  if (!has_target) {
-    if (ctx.json_output) {
-      nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
-      fmt.PrintJson(j);
-      return 0;
-    }
-    fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' daemon autostart is %s."), id,
-                                         it->autoStart ? _("enabled") : _("disabled")));
-    return 0;
-  }
-
-  it->autoStart = target_state;
+  it->autoStart = enable;
   NormalizeCoreConfig(&config);
   if (!SaveConfigOrFail(config, fmt)) {
     return 1;
@@ -403,8 +348,126 @@ int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state
     return 0;
   }
 
-  fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' daemon autostart set to %s."), id,
-                                       it->autoStart ? _("enabled") : _("disabled")));
+  if (enable) {
+    fmt.PrintSuccess(vinput::str::FmtStr(_("Adapter '%s' enabled to autostart with daemon."), id));
+  } else {
+    fmt.PrintSuccess(
+        vinput::str::FmtStr(_("Adapter '%s' disabled from autostart with daemon."), id));
+  }
+  return 0;
+}
+
+int RunLlmConfigEnableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
+  return SetAdapterAutostart(id, true, fmt, ctx);
+}
+
+int RunLlmConfigDisableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
+  return SetAdapterAutostart(id, false, fmt, ctx);
+}
+
+int RunLlmConfigPsAdapters(Formatter& fmt, const CliContext& ctx) {
+  CoreConfig config = LoadCoreConfig();
+  const auto installed_display_map =
+      vinput::cli::FetchScriptDisplayMap(config, vinput::script::Kind::kLlmAdapter);
+
+  if (ctx.json_output) {
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& adapter : config.llm.adapters) {
+      const auto it = installed_display_map.find(adapter.id);
+      const pid_t pid = vinput::adapter::GetPid(adapter.id);
+      const bool running = (pid > 0);
+      arr.push_back({
+          {"id", vinput::cli::HumanizeResourceId(installed_display_map, adapter.id)},
+          {"machine_id", adapter.id},
+          {"title", it == installed_display_map.end() ? "" : it->second.title},
+          {"status", running ? "running" : "stopped"},
+          {"running", running},
+          {"pid", running ? nlohmann::json(pid) : nullptr},
+          {"auto_start", adapter.autoStart},
+          {"command", adapter.command},
+      });
+    }
+    fmt.PrintJson(arr);
+    return 0;
+  }
+
+  std::vector<std::string> headers = {_("ID"), _("STATUS"), _("PID"), _("AUTOSTART"), _("COMMAND")};
+  std::vector<std::vector<std::string>> rows;
+  rows.reserve(config.llm.adapters.size());
+  for (const auto& adapter : config.llm.adapters) {
+    const pid_t pid = vinput::adapter::GetPid(adapter.id);
+    const bool running = (pid > 0);
+    rows.push_back({
+        vinput::cli::HumanizeResourceId(installed_display_map, adapter.id),
+        running ? _("running") : _("stopped"),
+        running ? std::to_string(pid) : "-",
+        adapter.autoStart ? _("enabled") : _("disabled"),
+        adapter.command,
+    });
+  }
+  fmt.PrintTable(headers, rows);
+  return 0;
+}
+
+int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx) {
+  CoreConfig config = LoadCoreConfig();
+  std::string error;
+  const std::string resolved_id =
+      vinput::cli::ResolveInstalledLlmAdapterSelector(config, id, &error);
+  if (resolved_id.empty()) {
+    fmt.PrintError(error);
+    return 1;
+  }
+
+  const auto* adapter = ResolveLlmAdapter(config, resolved_id);
+  if (!adapter) {
+    fmt.PrintError(vinput::str::FmtStr(_("Adapter '%s' not found."), id));
+    return 1;
+  }
+
+  const auto installed_display_map =
+      vinput::cli::FetchScriptDisplayMap(config, vinput::script::Kind::kLlmAdapter);
+  const auto it = installed_display_map.find(adapter->id);
+  const std::string title = (it == installed_display_map.end()) ? "" : it->second.title;
+  const pid_t pid = vinput::adapter::GetPid(adapter->id);
+  const bool running = (pid > 0);
+
+  if (ctx.json_output) {
+    nlohmann::json j = {
+        {"id", vinput::cli::HumanizeResourceId(installed_display_map, adapter->id)},
+        {"machine_id", adapter->id},
+        {"title", title},
+        {"status", running ? "running" : "stopped"},
+        {"running", running},
+        {"pid", running ? nlohmann::json(pid) : nullptr},
+        {"auto_start", adapter->autoStart},
+        {"command", adapter->command},
+        {"args", adapter->args},
+        {"env", adapter->env},
+    };
+    fmt.PrintJson(j);
+    return 0;
+  }
+
+  std::vector<std::string> headers = {_("PROPERTY"), _("VALUE")};
+  std::vector<std::vector<std::string>> rows = {
+      {_("ID"), vinput::cli::HumanizeResourceId(installed_display_map, adapter->id)},
+      {_("Title"), title},
+      {_("Status"), running ? _("running") : _("stopped")},
+      {_("PID"), running ? std::to_string(pid) : "-"},
+      {_("Autostart"), adapter->autoStart ? _("enabled") : _("disabled")},
+      {_("Command"), adapter->command},
+  };
+  if (!adapter->args.empty()) {
+    std::string args_joined;
+    for (size_t i = 0; i < adapter->args.size(); ++i) {
+      if (i > 0)
+        args_joined += " ";
+      args_joined += adapter->args[i];
+    }
+    rows.push_back({_("Args"), args_joined});
+  }
+  fmt.PrintTable(headers, rows);
   return 0;
 }
 

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -16,7 +16,9 @@
 #include "common/utils/string_utils.h"
 
 #include "cli/runtime/dbus_client.h"
+#include "cli/utils/cli_context.h"
 #include "cli/utils/cli_helpers.h"
+#include "cli/utils/formatter.h"
 #include "cli/utils/resource_utils.h"
 
 namespace {
@@ -45,6 +47,7 @@ int SetAdapterAutostart(const std::string& id, bool enable, Formatter& fmt, cons
   }
 
   if (ctx.json_output) {
+    // NOLINTNEXTLINE(misc-include-cleaner)
     const nlohmann::json j = {{"id", resolved_id}, {"auto_start", it->autoStart}};
     fmt.PrintJson(j);
     return 0;

--- a/src/cli/config/llm_actions.cpp
+++ b/src/cli/config/llm_actions.cpp
@@ -92,7 +92,6 @@ int RunLlmConfigListAdapters(bool available, Formatter& fmt, const CliContext& c
             {"command", adapter.command},
             {"args", adapter.args},
             {"env", adapter.env},
-            {"running", vinput::adapter::IsRunning(adapter.id)},
             {"auto_start", adapter.autoStart},
         });
       }

--- a/src/cli/config/llm_actions.h
+++ b/src/cli/config/llm_actions.h
@@ -7,6 +7,8 @@
 
 int RunLlmConfigList(Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigListAdapters(bool available, Formatter& fmt, const CliContext& ctx);
+int RunLlmConfigPsAdapters(Formatter& fmt, const CliContext& ctx);
+int RunLlmConfigStatusAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigAdd(const std::string& id, const std::string& baseUrl, const std::string& apiKey,
                     const std::string& extraBody, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigInstallAdapter(const std::string& selector, Formatter& fmt, const CliContext& ctx);
@@ -15,8 +17,6 @@ int RunLlmConfigStopAdapter(const std::string& id, Formatter& fmt, const CliCont
 int RunLlmConfigRestartAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigEnableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigDisableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
-int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state, bool enable,
-                                 bool disable, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigRemove(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigEdit(const std::string& id, const std::string& baseUrl, const std::string& apiKey,
                      const std::string& extraBody, bool hasBaseUrl, bool hasApiKey,

--- a/src/cli/config/llm_actions.h
+++ b/src/cli/config/llm_actions.h
@@ -12,6 +12,9 @@ int RunLlmConfigAdd(const std::string& id, const std::string& baseUrl, const std
 int RunLlmConfigInstallAdapter(const std::string& selector, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigStartAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigStopAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
+int RunLlmConfigRestartAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
+int RunLlmConfigEnableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
+int RunLlmConfigDisableAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state, bool enable,
                                  bool disable, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigRemove(const std::string& id, Formatter& fmt, const CliContext& ctx);

--- a/src/cli/config/llm_actions.h
+++ b/src/cli/config/llm_actions.h
@@ -12,6 +12,8 @@ int RunLlmConfigAdd(const std::string& id, const std::string& baseUrl, const std
 int RunLlmConfigInstallAdapter(const std::string& selector, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigStartAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigStopAdapter(const std::string& id, Formatter& fmt, const CliContext& ctx);
+int RunLlmConfigAutostartAdapter(const std::string& id, const std::string& state, bool enable,
+                                 bool disable, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigRemove(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunLlmConfigEdit(const std::string& id, const std::string& baseUrl, const std::string& apiKey,
                      const std::string& extraBody, bool hasBaseUrl, bool hasApiKey,

--- a/src/cli/config/register_llm.cpp
+++ b/src/cli/config/register_llm.cpp
@@ -124,6 +124,25 @@ void RegisterAdapterCommands(CLI::App& app, CliAction* action) {
       return RunLlmConfigStopAdapter(*stopId, fmt, ctx);
     };
   });
+
+  auto autostartId = std::make_shared<std::string>();
+  auto autostartState = std::make_shared<std::string>();
+  auto autostartEnable = std::make_shared<bool>(false);
+  auto autostartDisable = std::make_shared<bool>(false);
+  auto* autostart =
+      adapter->add_subcommand("autostart", _("Configure or show adapter autostart with daemon"));
+  autostart->add_option("id", *autostartId, _("Adapter short ID"))->required();
+  autostart->add_option("state", *autostartState,
+                        _("Target autostart state (on/off, enable/disable)"));
+  autostart->add_flag("-e,--enable", *autostartEnable, _("Enable autostart with daemon"));
+  autostart->add_flag("-d,--disable", *autostartDisable, _("Disable autostart with daemon"));
+  autostart->callback([action, autostartId, autostartState, autostartEnable, autostartDisable]() {
+    *action = [autostartId, autostartState, autostartEnable,
+               autostartDisable](Formatter& fmt, const CliContext& ctx) {
+      return RunLlmConfigAutostartAdapter(*autostartId, *autostartState, *autostartEnable,
+                                          *autostartDisable, fmt, ctx);
+    };
+  });
 }
 
 } // namespace vinput::cli::config

--- a/src/cli/config/register_llm.cpp
+++ b/src/cli/config/register_llm.cpp
@@ -125,6 +125,33 @@ void RegisterAdapterCommands(CLI::App& app, CliAction* action) {
     };
   });
 
+  auto restartId = std::make_shared<std::string>();
+  auto* restart = adapter->add_subcommand("restart", _("Restart an adapter"));
+  restart->add_option("id", *restartId, _("Adapter short ID"))->required();
+  restart->callback([action, restartId]() {
+    *action = [restartId](Formatter& fmt, const CliContext& ctx) {
+      return RunLlmConfigRestartAdapter(*restartId, fmt, ctx);
+    };
+  });
+
+  auto enableId = std::make_shared<std::string>();
+  auto* enable = adapter->add_subcommand("enable", _("Enable adapter autostart with daemon"));
+  enable->add_option("id", *enableId, _("Adapter short ID"))->required();
+  enable->callback([action, enableId]() {
+    *action = [enableId](Formatter& fmt, const CliContext& ctx) {
+      return RunLlmConfigEnableAdapter(*enableId, fmt, ctx);
+    };
+  });
+
+  auto disableId = std::make_shared<std::string>();
+  auto* disable = adapter->add_subcommand("disable", _("Disable adapter autostart with daemon"));
+  disable->add_option("id", *disableId, _("Adapter short ID"))->required();
+  disable->callback([action, disableId]() {
+    *action = [disableId](Formatter& fmt, const CliContext& ctx) {
+      return RunLlmConfigDisableAdapter(*disableId, fmt, ctx);
+    };
+  });
+
   auto autostartId = std::make_shared<std::string>();
   auto autostartState = std::make_shared<std::string>();
   auto autostartEnable = std::make_shared<bool>(false);

--- a/src/cli/config/register_llm.cpp
+++ b/src/cli/config/register_llm.cpp
@@ -98,6 +98,22 @@ void RegisterAdapterCommands(CLI::App& app, CliAction* action) {
     };
   });
 
+  auto* ps = adapter->add_subcommand("ps", _("List adapter processes and runtime status"));
+  ps->callback([action]() {
+    *action = [](Formatter& fmt, const CliContext& ctx) {
+      return RunLlmConfigPsAdapters(fmt, ctx);
+    };
+  });
+
+  auto statusId = std::make_shared<std::string>();
+  auto* status = adapter->add_subcommand("status", _("Show adapter status"));
+  status->add_option("id", *statusId, _("Adapter short ID"))->required();
+  status->callback([action, statusId]() {
+    *action = [statusId](Formatter& fmt, const CliContext& ctx) {
+      return RunLlmConfigStatusAdapter(*statusId, fmt, ctx);
+    };
+  });
+
   auto selector = std::make_shared<std::string>();
   auto* add = adapter->add_subcommand("add", _("Add an adapter"));
   add->add_option("id", *selector, _("Adapter short ID"))->required();
@@ -149,25 +165,6 @@ void RegisterAdapterCommands(CLI::App& app, CliAction* action) {
   disable->callback([action, disableId]() {
     *action = [disableId](Formatter& fmt, const CliContext& ctx) {
       return RunLlmConfigDisableAdapter(*disableId, fmt, ctx);
-    };
-  });
-
-  auto autostartId = std::make_shared<std::string>();
-  auto autostartState = std::make_shared<std::string>();
-  auto autostartEnable = std::make_shared<bool>(false);
-  auto autostartDisable = std::make_shared<bool>(false);
-  auto* autostart =
-      adapter->add_subcommand("autostart", _("Configure or show adapter autostart with daemon"));
-  autostart->add_option("id", *autostartId, _("Adapter short ID"))->required();
-  autostart->add_option("state", *autostartState,
-                        _("Target autostart state (on/off, enable/disable)"));
-  autostart->add_flag("-e,--enable", *autostartEnable, _("Enable autostart with daemon"));
-  autostart->add_flag("-d,--disable", *autostartDisable, _("Disable autostart with daemon"));
-  autostart->callback([action, autostartId, autostartState, autostartEnable, autostartDisable]() {
-    *action = [autostartId, autostartState, autostartEnable,
-               autostartDisable](Formatter& fmt, const CliContext& ctx) {
-      return RunLlmConfigAutostartAdapter(*autostartId, *autostartState, *autostartEnable,
-                                          *autostartDisable, fmt, ctx);
     };
   });
 }

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -51,6 +51,9 @@ void to_json(json& j, const LlmAdapter& p) {
   if (!p.env.empty()) {
     j["env"] = p.env;
   }
+  if (p.autoStart) {
+    j["auto_start"] = p.autoStart;
+  }
 }
 
 void from_json(const json& j, LlmAdapter& p) {
@@ -62,6 +65,7 @@ void from_json(const json& j, LlmAdapter& p) {
   if (j.contains("env") && j.at("env").is_object()) {
     p.env = j.at("env").get<std::map<std::string, std::string>>();
   }
+  p.autoStart = j.value("auto_start", p.autoStart);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/config/core_config_types.h
+++ b/src/common/config/core_config_types.h
@@ -27,6 +27,7 @@ struct LlmAdapter {
   std::string command;
   std::vector<std::string> args;
   std::map<std::string, std::string> env;
+  bool autoStart{false};
 };
 
 struct AsrProviderBase {

--- a/src/common/llm/adapter_manager.cpp
+++ b/src/common/llm/adapter_manager.cpp
@@ -135,8 +135,13 @@ void RemovePidFile(std::string_view adapter_id) {
   fs::remove(PidPath(adapter_id), ec);
 }
 
+pid_t GetPid(std::string_view adapter_id) {
+  const pid_t pid = ReadPid(adapter_id);
+  return ProcessExists(pid) ? pid : -1;
+}
+
 bool IsRunning(std::string_view adapter_id) {
-  return ProcessExists(ReadPid(adapter_id));
+  return GetPid(adapter_id) > 0;
 }
 
 bool Stop(std::string_view adapter_id, std::string* error) {

--- a/src/common/llm/adapter_manager.h
+++ b/src/common/llm/adapter_manager.h
@@ -18,6 +18,7 @@ std::filesystem::path ResolveWorkingDir(const LlmAdapter& adapter);
 std::filesystem::path PidPath(std::string_view adapter_id);
 bool WritePidFile(std::string_view adapter_id, pid_t pid, std::string* error);
 void RemovePidFile(std::string_view adapter_id);
+pid_t GetPid(std::string_view adapter_id);
 bool IsRunning(std::string_view adapter_id);
 bool Stop(std::string_view adapter_id, std::string* error);
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -179,6 +179,21 @@ public:
     return SubmitRequest(Request::Type::Stop, adapter_id);
   }
 
+  void AutoStart(const CoreConfig& config) {
+    for (const auto& adapter : config.llm.adapters) {
+      if (!adapter.autoStart) {
+        continue;
+      }
+      auto result = StartAdapter(adapter.id);
+      if (!result.ok) {
+        fprintf(stderr, "vinput-daemon: failed to autostart adapter '%s': %s\n", adapter.id.c_str(),
+                result.error.c_str());
+      } else {
+        vinput::debug::Log("autostarted adapter '%s'\n", adapter.id.c_str());
+      }
+    }
+  }
+
 private:
   struct ManagedAdapter {
     std::string id;
@@ -595,6 +610,7 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "vinput-daemon: %s\n", adapter_error.c_str());
     return 1;
   }
+  adapter_supervisor.AutoStart(startup_settings);
 
   runtime_controller.StartWorker();
   std::string remote_error;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -187,7 +187,7 @@ public:
       auto result = StartAdapter(adapter.id);
       if (!result.ok) {
         fprintf(stderr, "vinput-daemon: failed to autostart adapter '%s': %s\n", adapter.id.c_str(),
-                result.error.c_str());
+                result.message.c_str());
       } else {
         vinput::debug::Log("autostarted adapter '%s'\n", adapter.id.c_str());
       }

--- a/src/gui/dialogs/adapter_dialog.cpp
+++ b/src/gui/dialogs/adapter_dialog.cpp
@@ -9,6 +9,7 @@
 #include <QMessageBox>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <QtWidgets/qcheckbox.h>
 
 #include "utils/gui_helpers.h"
 
@@ -70,7 +71,6 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
     form->addRow(GuiTranslate("Args:"), textArgs);
     form->addRow(GuiTranslate("Env:"), textEnv);
 
-    // NOLINTNEXTLINE(misc-include-cleaner)
     auto* chkAutoStart = new QCheckBox(GuiTranslate("Start with daemon"));
     chkAutoStart->setChecked(initial.autoStart);
     form->addRow(QString(), chkAutoStart);

--- a/src/gui/dialogs/adapter_dialog.cpp
+++ b/src/gui/dialogs/adapter_dialog.cpp
@@ -1,5 +1,6 @@
 #include "dialogs/adapter_dialog.h"
 
+#include <QCheckBox>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QFormLayout>
@@ -68,6 +69,11 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
     form->addRow(GuiTranslate("Command / Interpreter:"), editCommand);
     form->addRow(GuiTranslate("Args:"), textArgs);
     form->addRow(GuiTranslate("Env:"), textEnv);
+
+    auto* chkAutoStart = new QCheckBox(GuiTranslate("Start with daemon"));
+    chkAutoStart->setChecked(initial.autoStart);
+    form->addRow(QString(), chkAutoStart);
+
     layout->addLayout(form);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -81,6 +87,7 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
 
     out_data->id = initial.id;
     out_data->command = editCommand->text().trimmed().toStdString();
+    out_data->autoStart = chkAutoStart->isChecked();
     out_data->args.clear();
     for (const QString& arg : NonEmptyLines(textArgs->toPlainText())) {
       out_data->args.push_back(arg.toStdString());

--- a/src/gui/dialogs/adapter_dialog.cpp
+++ b/src/gui/dialogs/adapter_dialog.cpp
@@ -70,6 +70,7 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
     form->addRow(GuiTranslate("Args:"), textArgs);
     form->addRow(GuiTranslate("Env:"), textEnv);
 
+    // NOLINTNEXTLINE(misc-include-cleaner)
     auto* chkAutoStart = new QCheckBox(GuiTranslate("Start with daemon"));
     chkAutoStart->setChecked(initial.autoStart);
     form->addRow(QString(), chkAutoStart);

--- a/src/gui/dialogs/adapter_dialog.h
+++ b/src/gui/dialogs/adapter_dialog.h
@@ -13,6 +13,7 @@ struct AdapterData {
   std::string command;
   std::vector<std::string> args;
   std::map<std::string, std::string> env;
+  bool autoStart{false};
 };
 
 // Show a dialog to edit an adapter's command/args/env.

--- a/src/gui/dialogs/adapter_dialog.h
+++ b/src/gui/dialogs/adapter_dialog.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QCheckBox>
 #include <QWidget>
 #include <map>
 #include <string>

--- a/src/gui/dialogs/adapter_dialog.h
+++ b/src/gui/dialogs/adapter_dialog.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QCheckBox>
 #include <QWidget>
 #include <map>
 #include <string>

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -111,7 +111,13 @@ void RunAdapterControlAsync(ControlPage* page, std::string adapter_id, bool star
 
 } // namespace
 
-ControlPage::ControlPage(QWidget* parent) : QWidget(parent) {
+ControlPage::ControlPage(QWidget* parent)
+    : QWidget(parent), comboDevice_(nullptr), chkNormalizeAudio_(nullptr), spinInputGain_(nullptr),
+      chkVadEnabled_(nullptr), chkDuckOutput_(nullptr), spinDuckVolume_(nullptr),
+      listAsrProviders_(nullptr), btnAsrEdit_(nullptr), btnAsrSetActive_(nullptr),
+      listAdapters_(nullptr), btnAdapterStart_(nullptr), btnAdapterStop_(nullptr),
+      chkAdapterAutostart_(nullptr), lblDaemonStatus_(nullptr), btnDaemonStart_(nullptr),
+      btnDaemonStop_(nullptr), btnDaemonRestart_(nullptr), daemonRefreshTimer_(nullptr) {
   auto* layout = new QVBoxLayout(this);
 
   // Audio section: capture device + audio processing knobs.

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -15,6 +15,7 @@
 #include <QSpinBox>
 #include <QThreadPool>
 #include <QVBoxLayout>
+#include <QWidget>
 #include <algorithm>
 
 #include "common/audio/pipewire_device.h"
@@ -111,13 +112,7 @@ void RunAdapterControlAsync(ControlPage* page, std::string adapter_id, bool star
 
 } // namespace
 
-ControlPage::ControlPage(QWidget* parent)
-    : QWidget(parent), comboDevice_(nullptr), chkNormalizeAudio_(nullptr), spinInputGain_(nullptr),
-      chkVadEnabled_(nullptr), chkDuckOutput_(nullptr), spinDuckVolume_(nullptr),
-      listAsrProviders_(nullptr), btnAsrEdit_(nullptr), btnAsrSetActive_(nullptr),
-      listAdapters_(nullptr), btnAdapterStart_(nullptr), btnAdapterStop_(nullptr),
-      chkAdapterAutostart_(nullptr), lblDaemonStatus_(nullptr), btnDaemonStart_(nullptr),
-      btnDaemonStop_(nullptr), btnDaemonRestart_(nullptr), daemonRefreshTimer_(nullptr) {
+ControlPage::ControlPage(QWidget* parent) : QWidget(parent) {
   auto* layout = new QVBoxLayout(this);
 
   // Audio section: capture device + audio processing knobs.
@@ -208,6 +203,7 @@ ControlPage::ControlPage(QWidget* parent)
   adapterLayout->addWidget(adapterTitle);
 
   auto* adapterListLayout = new QHBoxLayout();
+  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   listAdapters_ = new QListWidget();
   adapterListLayout->addWidget(listAdapters_);
 

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -112,7 +112,11 @@ void RunAdapterControlAsync(ControlPage* page, std::string adapter_id, bool star
 
 } // namespace
 
-ControlPage::ControlPage(QWidget* parent) : QWidget(parent) {
+ControlPage::ControlPage(QWidget* parent)
+    : QWidget(parent), listAdapters_(new QListWidget(this)),
+      btnAdapterStart_(new QPushButton(tr("Start"), this)),
+      btnAdapterStop_(new QPushButton(tr("Stop"), this)),
+      chkAdapterAutostart_(new QCheckBox(tr("Start with daemon"), this)) {
   auto* layout = new QVBoxLayout(this);
 
   // Audio section: capture device + audio processing knobs.
@@ -203,14 +207,9 @@ ControlPage::ControlPage(QWidget* parent) : QWidget(parent) {
   adapterLayout->addWidget(adapterTitle);
 
   auto* adapterListLayout = new QHBoxLayout();
-  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
-  listAdapters_ = new QListWidget();
   adapterListLayout->addWidget(listAdapters_);
 
   auto* adapterBtnLayout = new QVBoxLayout();
-  btnAdapterStart_ = new QPushButton(tr("Start"));
-  btnAdapterStop_ = new QPushButton(tr("Stop"));
-  chkAdapterAutostart_ = new QCheckBox(tr("Start with daemon"));
   chkAdapterAutostart_->setToolTip(
       tr("Automatically start this adapter when vinput-daemon starts."));
   adapterBtnLayout->addWidget(btnAdapterStart_);

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -15,6 +15,7 @@
 #include <QSpinBox>
 #include <QThreadPool>
 #include <QVBoxLayout>
+#include <algorithm>
 
 #include "common/audio/pipewire_device.h"
 #include "common/llm/adapter_manager.h"
@@ -92,7 +93,7 @@ template <typename Callback> void RunGetAsrBackendStateAsync(ControlPage* page, 
 template <typename Callback>
 void RunAdapterControlAsync(ControlPage* page, std::string adapter_id, bool start,
                             Callback callback) {
-  QPointer<ControlPage> self(page);
+  const QPointer<ControlPage> self(page);
   QThreadPool::globalInstance()->start(
       [self, adapter_id = std::move(adapter_id), start, callback = std::move(callback)]() mutable {
         vinput::cli::DbusClient dbus;
@@ -527,22 +528,23 @@ void ControlPage::onAsrSetActive() {
 
 void ControlPage::refreshAdapterList() {
   const QString current_selection =
-      listAdapters_->currentItem() ? listAdapters_->currentItem()->data(Qt::UserRole).toString()
-                                   : QString{};
+      (listAdapters_->currentItem() != nullptr)
+          ? listAdapters_->currentItem()->data(Qt::UserRole).toString()
+          : QString{};
 
   listAdapters_->clear();
-  CoreConfig config = ConfigManager::Get().Load();
+  const CoreConfig config = ConfigManager::Get().Load();
   const auto i18n_map = I18nCache::Get().GetMap();
 
   for (const auto& adapter : config.llm.adapters) {
-    QString id = QString::fromStdString(adapter.id);
-    QString title = QString::fromStdString(
+    const QString id = QString::fromStdString(adapter.id);
+    const QString title = QString::fromStdString(
         vinput::registry::LookupI18n(i18n_map, adapter.id + ".title", adapter.id));
-    bool running = vinput::adapter::IsRunning(adapter.id);
+    const bool running = vinput::adapter::IsRunning(adapter.id);
 
     QString display = title + " · " + (running ? GuiTranslate("running") : GuiTranslate("stopped"));
     display += " · " + (adapter.autoStart ? tr("autostart") : tr("manual"));
-    QString command = QString::fromStdString(adapter.command);
+    const QString command = QString::fromStdString(adapter.command);
     if (!command.isEmpty()) {
       display += " · " + command;
     }
@@ -559,14 +561,16 @@ void ControlPage::refreshAdapterList() {
     }
     if (!adapter.args.empty()) {
       QStringList argsList;
-      for (const auto& a : adapter.args)
+      for (const auto& a : adapter.args) {
         argsList << QString::fromStdString(a);
+      }
       tooltip += "\n" + tr("Args: %1").arg(argsList.join(" "));
     }
     if (!adapter.env.empty()) {
       QStringList envList;
-      for (const auto& [k, v] : adapter.env)
+      for (const auto& [k, v] : adapter.env) {
         envList << QString::fromStdString(k) + "=" + QString::fromStdString(v);
+      }
       tooltip += "\n" + tr("Env: %1").arg(envList.join(" "));
     }
     item->setToolTip(tooltip.trimmed());
@@ -580,7 +584,7 @@ void ControlPage::refreshAdapterList() {
 
 void ControlPage::updateAdapterButtons() {
   auto* item = listAdapters_->currentItem();
-  if (!item) {
+  if (item == nullptr) {
     btnAdapterStart_->setEnabled(false);
     btnAdapterStop_->setEnabled(false);
     chkAdapterAutostart_->setEnabled(false);
@@ -601,7 +605,7 @@ void ControlPage::updateAdapterButtons() {
 
 void ControlPage::onAdapterStart() {
   auto* item = listAdapters_->currentItem();
-  if (!item) {
+  if (item == nullptr) {
     return;
   }
   const QString adapter_id = item->data(Qt::UserRole).toString();
@@ -622,7 +626,7 @@ void ControlPage::onAdapterStart() {
 
 void ControlPage::onAdapterStop() {
   auto* item = listAdapters_->currentItem();
-  if (!item) {
+  if (item == nullptr) {
     return;
   }
   const QString adapter_id = item->data(Qt::UserRole).toString();
@@ -643,7 +647,7 @@ void ControlPage::onAdapterStop() {
 
 void ControlPage::onAdapterAutostartToggled(bool checked) {
   auto* item = listAdapters_->currentItem();
-  if (!item) {
+  if (item == nullptr) {
     return;
   }
   const QString adapter_id = item->data(Qt::UserRole).toString();

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -9,13 +9,19 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLabel>
+#include <QListWidget>
 #include <QListWidgetItem>
 #include <QMessageBox>
 #include <QPointer>
+#include <QPushButton>
 #include <QSpinBox>
 #include <QThreadPool>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QtWidgets/qcheckbox.h>
+#include <QtWidgets/qlistwidget.h>
+#include <QtWidgets/qpushbutton.h>
+#include <QtWidgets/qwidget.h>
 #include <algorithm>
 
 #include "common/audio/pipewire_device.h"

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -17,6 +17,8 @@
 #include <QVBoxLayout>
 
 #include "common/audio/pipewire_device.h"
+#include "common/llm/adapter_manager.h"
+#include "common/registry/registry_i18n.h"
 #include "common/utils/sandbox.h"
 
 #include "cli/runtime/dbus_client.h"
@@ -85,6 +87,25 @@ template <typename Callback> void RunGetAsrBackendStateAsync(ControlPage* page, 
                                 callback(ok, state, err);
                               });
   });
+}
+
+template <typename Callback>
+void RunAdapterControlAsync(ControlPage* page, std::string adapter_id, bool start,
+                            Callback callback) {
+  QPointer<ControlPage> self(page);
+  QThreadPool::globalInstance()->start(
+      [self, adapter_id = std::move(adapter_id), start, callback = std::move(callback)]() mutable {
+        vinput::cli::DbusClient dbus;
+        std::string err;
+        const bool ok =
+            start ? dbus.StartAdapter(adapter_id, &err) : dbus.StopAdapter(adapter_id, &err);
+        QMetaObject::invokeMethod(self, [self, callback = std::move(callback), ok, err]() mutable {
+          if (!self) {
+            return;
+          }
+          callback(ok, err);
+        });
+      });
 }
 
 } // namespace
@@ -169,6 +190,45 @@ ControlPage::ControlPage(QWidget* parent) : QWidget(parent) {
 
   connect(&I18nCache::Get(), &I18nCache::mapUpdated, this, &ControlPage::refreshAsrList);
 
+  layout->addSpacing(20);
+
+  // Adapters section
+  auto* adapterFrame = new QFrame();
+  adapterFrame->setFrameShape(QFrame::StyledPanel);
+  auto* adapterLayout = new QVBoxLayout(adapterFrame);
+
+  auto* adapterTitle = new QLabel(tr("<b>Adapters</b>"));
+  adapterLayout->addWidget(adapterTitle);
+
+  auto* adapterListLayout = new QHBoxLayout();
+  listAdapters_ = new QListWidget();
+  adapterListLayout->addWidget(listAdapters_);
+
+  auto* adapterBtnLayout = new QVBoxLayout();
+  btnAdapterStart_ = new QPushButton(tr("Start"));
+  btnAdapterStop_ = new QPushButton(tr("Stop"));
+  chkAdapterAutostart_ = new QCheckBox(tr("Start with daemon"));
+  chkAdapterAutostart_->setToolTip(
+      tr("Automatically start this adapter when vinput-daemon starts."));
+  adapterBtnLayout->addWidget(btnAdapterStart_);
+  adapterBtnLayout->addWidget(btnAdapterStop_);
+  adapterBtnLayout->addWidget(chkAdapterAutostart_);
+  adapterBtnLayout->addStretch();
+  adapterListLayout->addLayout(adapterBtnLayout);
+  adapterLayout->addLayout(adapterListLayout);
+  layout->addWidget(adapterFrame);
+
+  connect(btnAdapterStart_, &QPushButton::clicked, this, &ControlPage::onAdapterStart);
+  connect(btnAdapterStop_, &QPushButton::clicked, this, &ControlPage::onAdapterStop);
+  connect(chkAdapterAutostart_, &QCheckBox::toggled, this, &ControlPage::onAdapterAutostartToggled);
+  connect(listAdapters_, &QListWidget::itemSelectionChanged, this,
+          &ControlPage::updateAdapterButtons);
+  btnAdapterStart_->setEnabled(false);
+  btnAdapterStop_->setEnabled(false);
+  chkAdapterAutostart_->setEnabled(false);
+
+  connect(&I18nCache::Get(), &I18nCache::mapUpdated, this, &ControlPage::refreshAdapterList);
+
   // Daemon section
   auto* daemonFrame = new QFrame();
   daemonFrame->setFrameShape(QFrame::StyledPanel);
@@ -238,6 +298,7 @@ void ControlPage::reload() {
   }
 
   refreshAsrList();
+  refreshAdapterList();
 }
 
 QString ControlPage::currentDevice() const {
@@ -464,7 +525,152 @@ void ControlPage::onAsrSetActive() {
   });
 }
 
+void ControlPage::refreshAdapterList() {
+  const QString current_selection =
+      listAdapters_->currentItem() ? listAdapters_->currentItem()->data(Qt::UserRole).toString()
+                                   : QString{};
+
+  listAdapters_->clear();
+  CoreConfig config = ConfigManager::Get().Load();
+  const auto i18n_map = I18nCache::Get().GetMap();
+
+  for (const auto& adapter : config.llm.adapters) {
+    QString id = QString::fromStdString(adapter.id);
+    QString title = QString::fromStdString(
+        vinput::registry::LookupI18n(i18n_map, adapter.id + ".title", adapter.id));
+    bool running = vinput::adapter::IsRunning(adapter.id);
+
+    QString display = title + " · " + (running ? GuiTranslate("running") : GuiTranslate("stopped"));
+    display += " · " + (adapter.autoStart ? tr("autostart") : tr("manual"));
+    QString command = QString::fromStdString(adapter.command);
+    if (!command.isEmpty()) {
+      display += " · " + command;
+    }
+
+    auto* item = new QListWidgetItem(display, listAdapters_);
+    item->setData(Qt::UserRole, id);
+    item->setData(Qt::UserRole + 1, running);
+    item->setData(Qt::UserRole + 2, title);
+    item->setData(Qt::UserRole + 3, adapter.autoStart);
+
+    QString tooltip;
+    if (!command.isEmpty()) {
+      tooltip += "\n" + tr("Command: %1").arg(command);
+    }
+    if (!adapter.args.empty()) {
+      QStringList argsList;
+      for (const auto& a : adapter.args)
+        argsList << QString::fromStdString(a);
+      tooltip += "\n" + tr("Args: %1").arg(argsList.join(" "));
+    }
+    if (!adapter.env.empty()) {
+      QStringList envList;
+      for (const auto& [k, v] : adapter.env)
+        envList << QString::fromStdString(k) + "=" + QString::fromStdString(v);
+      tooltip += "\n" + tr("Env: %1").arg(envList.join(" "));
+    }
+    item->setToolTip(tooltip.trimmed());
+
+    if (id == current_selection) {
+      listAdapters_->setCurrentItem(item);
+    }
+  }
+  updateAdapterButtons();
+}
+
+void ControlPage::updateAdapterButtons() {
+  auto* item = listAdapters_->currentItem();
+  if (!item) {
+    btnAdapterStart_->setEnabled(false);
+    btnAdapterStop_->setEnabled(false);
+    chkAdapterAutostart_->setEnabled(false);
+    chkAdapterAutostart_->blockSignals(true);
+    chkAdapterAutostart_->setChecked(false);
+    chkAdapterAutostart_->blockSignals(false);
+    return;
+  }
+  const bool running = item->data(Qt::UserRole + 1).toBool();
+  const bool autostart = item->data(Qt::UserRole + 3).toBool();
+  btnAdapterStart_->setEnabled(!running);
+  btnAdapterStop_->setEnabled(running);
+  chkAdapterAutostart_->setEnabled(true);
+  chkAdapterAutostart_->blockSignals(true);
+  chkAdapterAutostart_->setChecked(autostart);
+  chkAdapterAutostart_->blockSignals(false);
+}
+
+void ControlPage::onAdapterStart() {
+  auto* item = listAdapters_->currentItem();
+  if (!item) {
+    return;
+  }
+  const QString adapter_id = item->data(Qt::UserRole).toString();
+
+  btnAdapterStart_->setEnabled(false);
+  btnAdapterStop_->setEnabled(false);
+  RunAdapterControlAsync(this, adapter_id.toStdString(), true,
+                         [this](bool ok, const std::string& err) {
+                           btnAdapterStart_->setEnabled(true);
+                           btnAdapterStop_->setEnabled(true);
+                           if (!ok) {
+                             QMessageBox::warning(this, tr("Error"), QString::fromStdString(err));
+                             return;
+                           }
+                           refreshAdapterList();
+                         });
+}
+
+void ControlPage::onAdapterStop() {
+  auto* item = listAdapters_->currentItem();
+  if (!item) {
+    return;
+  }
+  const QString adapter_id = item->data(Qt::UserRole).toString();
+
+  btnAdapterStart_->setEnabled(false);
+  btnAdapterStop_->setEnabled(false);
+  RunAdapterControlAsync(this, adapter_id.toStdString(), false,
+                         [this](bool ok, const std::string& err) {
+                           btnAdapterStart_->setEnabled(true);
+                           btnAdapterStop_->setEnabled(true);
+                           if (!ok) {
+                             QMessageBox::warning(this, tr("Error"), QString::fromStdString(err));
+                             return;
+                           }
+                           refreshAdapterList();
+                         });
+}
+
+void ControlPage::onAdapterAutostartToggled(bool checked) {
+  auto* item = listAdapters_->currentItem();
+  if (!item) {
+    return;
+  }
+  const QString adapter_id = item->data(Qt::UserRole).toString();
+
+  CoreConfig config = ConfigManager::Get().Load();
+  auto it =
+      std::find_if(config.llm.adapters.begin(), config.llm.adapters.end(),
+                   [&adapter_id](const LlmAdapter& a) { return a.id == adapter_id.toStdString(); });
+  if (it == config.llm.adapters.end()) {
+    return;
+  }
+
+  if (it->autoStart == checked) {
+    return;
+  }
+
+  it->autoStart = checked;
+  if (!ConfigManager::Get().Save(config)) {
+    QMessageBox::critical(this, tr("Error"), tr("Failed to save config."));
+    return;
+  }
+  refreshAdapterList();
+  emit configChanged();
+}
+
 void ControlPage::refreshDaemonStatus() {
+  refreshAdapterList();
   vinput::cli::DbusClient dbus;
   std::string err;
   if (!dbus.IsDaemonRunning(&err)) {

--- a/src/gui/pages/control/control_page.h
+++ b/src/gui/pages/control/control_page.h
@@ -71,10 +71,10 @@ private:
   QPushButton* btnAsrEdit_;
   QPushButton* btnAsrSetActive_;
 
-  QListWidget* listAdapters_;
-  QPushButton* btnAdapterStart_;
-  QPushButton* btnAdapterStop_;
-  QCheckBox* chkAdapterAutostart_;
+  QListWidget* listAdapters_ = nullptr;
+  QPushButton* btnAdapterStart_ = nullptr;
+  QPushButton* btnAdapterStop_ = nullptr;
+  QCheckBox* chkAdapterAutostart_ = nullptr;
 
   QLabel* lblDaemonStatus_;
   QPushButton* btnDaemonStart_;

--- a/src/gui/pages/control/control_page.h
+++ b/src/gui/pages/control/control_page.h
@@ -71,10 +71,10 @@ private:
   QPushButton* btnAsrEdit_;
   QPushButton* btnAsrSetActive_;
 
-  QListWidget* listAdapters_ = nullptr;
-  QPushButton* btnAdapterStart_ = nullptr;
-  QPushButton* btnAdapterStop_ = nullptr;
-  QCheckBox* chkAdapterAutostart_ = nullptr;
+  QListWidget* listAdapters_;
+  QPushButton* btnAdapterStart_;
+  QPushButton* btnAdapterStop_;
+  QCheckBox* chkAdapterAutostart_;
 
   QLabel* lblDaemonStatus_;
   QPushButton* btnDaemonStart_;

--- a/src/gui/pages/control/control_page.h
+++ b/src/gui/pages/control/control_page.h
@@ -44,6 +44,12 @@ private slots:
   void onAsrEdit();
   void onAsrSetActive();
 
+  void refreshAdapterList();
+  void updateAdapterButtons();
+  void onAdapterStart();
+  void onAdapterStop();
+  void onAdapterAutostartToggled(bool checked);
+
   void refreshDaemonStatus();
   void onDaemonStart();
   void onDaemonStop();
@@ -64,6 +70,11 @@ private:
   QListWidget* listAsrProviders_;
   QPushButton* btnAsrEdit_;
   QPushButton* btnAsrSetActive_;
+
+  QListWidget* listAdapters_;
+  QPushButton* btnAdapterStart_;
+  QPushButton* btnAdapterStop_;
+  QCheckBox* chkAdapterAutostart_;
 
   QLabel* lblDaemonStatus_;
   QPushButton* btnDaemonStart_;

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -127,11 +127,11 @@ QString AdapterTitleForGui(const std::string& adapter_id) {
 
 // Convert between AdapterData (GUI dialog) and LlmAdapter (config).
 AdapterData AdapterDataFromConfig(const LlmAdapter& a) {
-  return {a.id, a.command, a.args, a.env};
+  return {a.id, a.command, a.args, a.env, a.autoStart};
 }
 
 LlmAdapter LlmAdapterFromDialog(const AdapterData& d) {
-  return {d.id, d.command, d.args, d.env};
+  return {d.id, d.command, d.args, d.env, d.autoStart};
 }
 
 template <typename Callback>
@@ -272,6 +272,7 @@ void LlmPage::refreshAdapterList() {
     bool running = vinput::adapter::IsRunning(adapter.id);
 
     QString display = title + " · " + (running ? GuiTranslate("running") : GuiTranslate("stopped"));
+    display += " · " + (adapter.autoStart ? tr("autostart") : tr("manual"));
     QString command = QString::fromStdString(adapter.command);
     if (!command.isEmpty()) {
       display += " · " + command;
@@ -281,9 +282,11 @@ void LlmPage::refreshAdapterList() {
     item->setData(Qt::UserRole, id);
     item->setData(Qt::UserRole + 1, running);
     item->setData(Qt::UserRole + 2, title);
+    item->setData(Qt::UserRole + 3, adapter.autoStart);
 
     // Build tooltip
     QString tooltip;
+    tooltip += tr("Autostart: %1").arg(adapter.autoStart ? tr("enabled") : tr("disabled"));
     if (!command.isEmpty()) {
       tooltip += "\n" + tr("Command: %1").arg(command);
     }


### PR DESCRIPTION
Closes #147

### Implementation Tasks
- [x] 1. Core data structures and config: add autoStart to LlmAdapter with JSON serialization
- [x] 2. Daemon startup: automatically launch autostart-enabled adapters in AdapterSupervisor
- [x] 3. CLI commands: support 'adapter ps', 'adapter status <id>', 'adapter enable/disable', and clean 'adapter ls'
- [x] 4. GUI Control page: add Adapter management section with start/stop buttons and autostart toggle
- [x] 5. GUI LLM page & Dialog: update adapter list and edit dialog with autostart support
- [x] 6. Shell completions, man pages, and site documentation updated (Bash/Zsh/Fish)
- [x] 7. Quality gate, formatting, and i18n checks