### PR TITLE
feat: decouple raw transcript availability from LLM candidates (#140)

### DIFF
--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -180,7 +180,7 @@ _vinput() {
                 case "${words[2]}" in
                     add|edit|e)
                         if [[ "$cur" == -* ]]; then
-                            COMPREPLY=($(compgen -W "--id -l --label -t --prompt -p --provider -m --model -c --candidates --llm-max-candidates --timeout --context-lines -h --help" -- "$cur"))
+                            COMPREPLY=($(compgen -W "--id -l --label -t --prompt -p --provider -m --model -c --count --candidates --max --timeout --context-lines -h --help" -- "$cur"))
                         else
                             COMPREPLY=($(compgen -W "$(_vinput_installed_scenes)" -- "$cur"))
                         fi

--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -180,7 +180,7 @@ _vinput() {
                 case "${words[2]}" in
                     add|edit|e)
                         if [[ "$cur" == -* ]]; then
-                            COMPREPLY=($(compgen -W "--id -l --label -t --prompt -p --provider -m --model -c --count --candidates --max --timeout --context-lines -h --help" -- "$cur"))
+                            COMPREPLY=($(compgen -W "--id -l --label -t --prompt -p --provider -m --model -c --count --timeout --context-lines -h --help" -- "$cur"))
                         else
                             COMPREPLY=($(compgen -W "$(_vinput_installed_scenes)" -- "$cur"))
                         fi

--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -180,7 +180,7 @@ _vinput() {
                 case "${words[2]}" in
                     add|edit|e)
                         if [[ "$cur" == -* ]]; then
-                            COMPREPLY=($(compgen -W "--id -l --label -t --prompt -p --provider -m --model -c --candidates --timeout --context-lines -h --help" -- "$cur"))
+                            COMPREPLY=($(compgen -W "--id -l --label -t --prompt -p --provider -m --model -c --candidates --llm-max-candidates --timeout --context-lines -h --help" -- "$cur"))
                         else
                             COMPREPLY=($(compgen -W "$(_vinput_installed_scenes)" -- "$cur"))
                         fi

--- a/data/completions/fish/vinput.fish
+++ b/data/completions/fish/vinput.fish
@@ -110,7 +110,7 @@ complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcom
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s t -l prompt -d "LLM prompt"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s p -l provider -a "(__fish_vinput_installed_llm_providers)" -d "LLM provider ID"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s m -l model -d "LLM model ID"
-complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s c -l candidates -d "Candidate count"
+complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s c -l candidates -l llm-max-candidates -d "Maximum number of LLM candidates"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l timeout -d "Request timeout in ms"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l context-lines -d "Context history lines"
 

--- a/data/completions/fish/vinput.fish
+++ b/data/completions/fish/vinput.fish
@@ -110,7 +110,7 @@ complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcom
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s t -l prompt -d "LLM prompt"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s p -l provider -a "(__fish_vinput_installed_llm_providers)" -d "LLM provider ID"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s m -l model -d "LLM model ID"
-complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s c -l count -l candidates -l max -d "Maximum number of LLM candidates"
+complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s c -l count -d "Maximum number of LLM candidates"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l timeout -d "Request timeout in ms"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l context-lines -d "Context history lines"
 

--- a/data/completions/fish/vinput.fish
+++ b/data/completions/fish/vinput.fish
@@ -110,7 +110,7 @@ complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcom
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s t -l prompt -d "LLM prompt"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s p -l provider -a "(__fish_vinput_installed_llm_providers)" -d "LLM provider ID"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s m -l model -d "LLM model ID"
-complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s c -l candidates -l llm-max-candidates -d "Maximum number of LLM candidates"
+complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -s c -l count -l candidates -l max -d "Maximum number of LLM candidates"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l timeout -d "Request timeout in ms"
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l context-lines -d "Context history lines"
 

--- a/data/completions/zsh/_vinput
+++ b/data/completions/zsh/_vinput
@@ -334,7 +334,7 @@ _vinput() {
                                         '(-t --prompt)'{-t,--prompt}'[LLM prompt]:prompt:' \
                                         '(-p --provider)'{-p,--provider}'[LLM provider ID]:provider:_vinput_installed_llm_providers' \
                                         '(-m --model)'{-m,--model}'[LLM model ID]:model:' \
-                                        '(-c --count --candidates --max)'{-c,--count,--candidates,--max}'[Maximum number of LLM candidates]:count:' \
+                                        '(-c --count)'{-c,--count}'[Maximum number of LLM candidates]:count:' \
                                         '--timeout[Request timeout in ms]:ms:' \
                                         '--context-lines[Context history lines]:lines:' \
                                         '1:scene:_vinput_installed_scenes' ;;

--- a/data/completions/zsh/_vinput
+++ b/data/completions/zsh/_vinput
@@ -334,7 +334,7 @@ _vinput() {
                                         '(-t --prompt)'{-t,--prompt}'[LLM prompt]:prompt:' \
                                         '(-p --provider)'{-p,--provider}'[LLM provider ID]:provider:_vinput_installed_llm_providers' \
                                         '(-m --model)'{-m,--model}'[LLM model ID]:model:' \
-                                        '(-c --candidates --llm-max-candidates)'{-c,--candidates,--llm-max-candidates}'[Maximum number of LLM candidates]:count:' \
+                                        '(-c --count --candidates --max)'{-c,--count,--candidates,--max}'[Maximum number of LLM candidates]:count:' \
                                         '--timeout[Request timeout in ms]:ms:' \
                                         '--context-lines[Context history lines]:lines:' \
                                         '1:scene:_vinput_installed_scenes' ;;

--- a/data/completions/zsh/_vinput
+++ b/data/completions/zsh/_vinput
@@ -334,7 +334,7 @@ _vinput() {
                                         '(-t --prompt)'{-t,--prompt}'[LLM prompt]:prompt:' \
                                         '(-p --provider)'{-p,--provider}'[LLM provider ID]:provider:_vinput_installed_llm_providers' \
                                         '(-m --model)'{-m,--model}'[LLM model ID]:model:' \
-                                        '(-c --candidates)'{-c,--candidates}'[Candidate count]:count:' \
+                                        '(-c --candidates --llm-max-candidates)'{-c,--candidates,--llm-max-candidates}'[Maximum number of LLM candidates]:count:' \
                                         '--timeout[Request timeout in ms]:ms:' \
                                         '--context-lines[Context history lines]:lines:' \
                                         '1:scene:_vinput_installed_scenes' ;;

--- a/data/default-config.json
+++ b/data/default-config.json
@@ -38,7 +38,7 @@
       {
         "id": "__raw__",
         "label": "__label_raw__",
-        "llm_max_candidates": 0
+        "count": 0
       },
       {
         "id": "__command__",

--- a/data/default-config.json
+++ b/data/default-config.json
@@ -38,7 +38,7 @@
       {
         "id": "__raw__",
         "label": "__label_raw__",
-        "candidate_count": 0
+        "llm_max_candidates": 0
       },
       {
         "id": "__command__",

--- a/data/man/en/vinput-config.5
+++ b/data/man/en/vinput-config.5
@@ -106,7 +106,7 @@ Defines prompt templates and candidate counts for text rewriting.
   \(dqdefinitions\(dq: [
     {
       \(dqid\(dq: \(dq__raw__\(dq,
-      \(dqllm_max_candidates\(dq: 0
+      \(dqcount\(dq: 0
     },
     {
       \(dqid\(dq: \(dqdefault\(dq,
@@ -115,7 +115,7 @@ Defines prompt templates and candidate counts for text rewriting.
       \(dqprovider_id\(dq: \(dqgroq\(dq,
       \(dqmodel\(dq: \(dqllama\-3.3\-70b\-versatile\(dq,
       \(dqcontext_lines\(dq: 3,
-      \(dqllm_max_candidates\(dq: 5
+      \(dqcount\(dq: 5
     }
   ]
 }
@@ -129,7 +129,7 @@ ID of the currently selected scene.
 Number of preceding input lines sent to the LLM as conversational
 context.
 .TP
-\f[B]llm_max_candidates\f[R] (\f[I]integer\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
+\f[B]count\f[R] (\f[I]integer\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
 Maximum number of rewritten candidates requested from the LLM (set to
 \f[CR]0\f[R] to disable LLM for this scene).
 Candidates are deduplicated with the raw ASR transcript.

--- a/data/man/en/vinput-config.5
+++ b/data/man/en/vinput-config.5
@@ -128,6 +128,14 @@ ID of the currently selected scene.
 \f[B]context_lines\f[R] (\f[I]integer\f[R])
 Number of preceding input lines sent to the LLM as conversational
 context.
+.TP
+\f[B]candidate_count\f[R] (\f[I]integer\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
+Maximum number of rewritten candidates requested from the LLM (set to
+\f[CR]0\f[R] to disable LLM for this scene).
+Candidates are deduplicated with the raw ASR transcript.
+If only 1 distinct candidate remains, it commits directly to screen; if
+distinct choices exist, a candidate menu is shown with the primary LLM
+rewrite focused and the raw transcript preserved as option 1.
 .SH VINPUT.CONF STRUCTURE (FCITX5 ADDON)
 The Fcitx5 addon configuration file is stored in INI format at
 \f[I]\(ti/.config/fcitx5/conf/vinput.conf\f[R].

--- a/data/man/en/vinput-config.5
+++ b/data/man/en/vinput-config.5
@@ -106,7 +106,7 @@ Defines prompt templates and candidate counts for text rewriting.
   \(dqdefinitions\(dq: [
     {
       \(dqid\(dq: \(dq__raw__\(dq,
-      \(dqcandidate_count\(dq: 0
+      \(dqllm_max_candidates\(dq: 0
     },
     {
       \(dqid\(dq: \(dqdefault\(dq,
@@ -115,7 +115,7 @@ Defines prompt templates and candidate counts for text rewriting.
       \(dqprovider_id\(dq: \(dqgroq\(dq,
       \(dqmodel\(dq: \(dqllama\-3.3\-70b\-versatile\(dq,
       \(dqcontext_lines\(dq: 3,
-      \(dqcandidate_count\(dq: 5
+      \(dqllm_max_candidates\(dq: 5
     }
   ]
 }
@@ -129,7 +129,7 @@ ID of the currently selected scene.
 Number of preceding input lines sent to the LLM as conversational
 context.
 .TP
-\f[B]candidate_count\f[R] (\f[I]integer\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
+\f[B]llm_max_candidates\f[R] (\f[I]integer\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
 Maximum number of rewritten candidates requested from the LLM (set to
 \f[CR]0\f[R] to disable LLM for this scene).
 Candidates are deduplicated with the raw ASR transcript.

--- a/data/man/en/vinput-config.5.md
+++ b/data/man/en/vinput-config.5.md
@@ -130,6 +130,9 @@ Defines prompt templates and candidate counts for text rewriting.
 **context_lines** (*integer*)
 :   Number of preceding input lines sent to the LLM as conversational context.
 
+**candidate_count** (*integer*, `0` - `9`)
+:   Maximum number of rewritten candidates requested from the LLM (set to `0` to disable LLM for this scene). Candidates are deduplicated with the raw ASR transcript. If only 1 distinct candidate remains, it commits directly to screen; if distinct choices exist, a candidate menu is shown with the primary LLM rewrite focused and the raw transcript preserved as option 1.
+
 # VINPUT.CONF STRUCTURE (FCITX5 ADDON)
 
 The Fcitx5 addon configuration file is stored in INI format at *~/.config/fcitx5/conf/vinput.conf*.

--- a/data/man/en/vinput-config.5.md
+++ b/data/man/en/vinput-config.5.md
@@ -109,7 +109,7 @@ Defines prompt templates and candidate counts for text rewriting.
   "definitions": [
     {
       "id": "__raw__",
-      "candidate_count": 0
+      "llm_max_candidates": 0
     },
     {
       "id": "default",
@@ -118,7 +118,7 @@ Defines prompt templates and candidate counts for text rewriting.
       "provider_id": "groq",
       "model": "llama-3.3-70b-versatile",
       "context_lines": 3,
-      "candidate_count": 5
+      "llm_max_candidates": 5
     }
   ]
 }
@@ -130,7 +130,7 @@ Defines prompt templates and candidate counts for text rewriting.
 **context_lines** (*integer*)
 :   Number of preceding input lines sent to the LLM as conversational context.
 
-**candidate_count** (*integer*, `0` - `9`)
+**llm_max_candidates** (*integer*, `0` - `9`)
 :   Maximum number of rewritten candidates requested from the LLM (set to `0` to disable LLM for this scene). Candidates are deduplicated with the raw ASR transcript. If only 1 distinct candidate remains, it commits directly to screen; if distinct choices exist, a candidate menu is shown with the primary LLM rewrite focused and the raw transcript preserved as option 1.
 
 # VINPUT.CONF STRUCTURE (FCITX5 ADDON)

--- a/data/man/en/vinput-config.5.md
+++ b/data/man/en/vinput-config.5.md
@@ -109,7 +109,7 @@ Defines prompt templates and candidate counts for text rewriting.
   "definitions": [
     {
       "id": "__raw__",
-      "llm_max_candidates": 0
+      "count": 0
     },
     {
       "id": "default",
@@ -118,7 +118,7 @@ Defines prompt templates and candidate counts for text rewriting.
       "provider_id": "groq",
       "model": "llama-3.3-70b-versatile",
       "context_lines": 3,
-      "llm_max_candidates": 5
+      "count": 5
     }
   ]
 }
@@ -130,7 +130,7 @@ Defines prompt templates and candidate counts for text rewriting.
 **context_lines** (*integer*)
 :   Number of preceding input lines sent to the LLM as conversational context.
 
-**llm_max_candidates** (*integer*, `0` - `9`)
+**count** (*integer*, `0` - `9`)
 :   Maximum number of rewritten candidates requested from the LLM (set to `0` to disable LLM for this scene). Candidates are deduplicated with the raw ASR transcript. If only 1 distinct candidate remains, it commits directly to screen; if distinct choices exist, a candidate menu is shown with the primary LLM rewrite focused and the raw transcript preserved as option 1.
 
 # VINPUT.CONF STRUCTURE (FCITX5 ADDON)

--- a/data/man/en/vinput.1
+++ b/data/man/en/vinput.1
@@ -153,7 +153,7 @@ rewrite raw ASR text.
 \f[B]scene list\f[R]
 List all defined recognition scenes.
 .TP
-\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-candidates\f[R], \f[B]\-\-llm\-max\-candidates\f[R] \f[I]N\f[R]]
+\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-count\f[R] \f[I]N\f[R]]
 Add a new scene definition.
 \f[I]N\f[R] is the maximum number of distinct rewrites requested from
 the LLM; \f[CR]0\f[R] disables LLM processing for the scene.

--- a/data/man/en/vinput.1
+++ b/data/man/en/vinput.1
@@ -153,8 +153,10 @@ rewrite raw ASR text.
 \f[B]scene list\f[R]
 List all defined recognition scenes.
 .TP
-\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-candidates\f[R] \f[I]N\f[R]]
+\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-candidates\f[R], \f[B]\-\-llm\-max\-candidates\f[R] \f[I]N\f[R]]
 Add a new scene definition.
+\f[I]N\f[R] is the maximum number of distinct rewrites requested from
+the LLM; \f[CR]0\f[R] disables LLM processing for the scene.
 .TP
 \f[B]scene edit\f[R] \f[I]ID\f[R] [\f[I]OPTIONS\f[R]]
 Modify an existing scene configuration.

--- a/data/man/en/vinput.1.md
+++ b/data/man/en/vinput.1.md
@@ -145,7 +145,7 @@ Scenes define prompt templates and bound LLM configurations used to rewrite raw 
 **scene list**
 :   List all defined recognition scenes.
 
-**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--candidates**, **--llm-max-candidates** *N*]
+**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--count** *N*]
 :   Add a new scene definition. *N* is the maximum number of distinct rewrites requested from the LLM; `0` disables LLM processing for the scene.
 
 **scene edit** *ID* [*OPTIONS*]

--- a/data/man/en/vinput.1.md
+++ b/data/man/en/vinput.1.md
@@ -145,8 +145,8 @@ Scenes define prompt templates and bound LLM configurations used to rewrite raw 
 **scene list**
 :   List all defined recognition scenes.
 
-**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--candidates** *N*]
-:   Add a new scene definition.
+**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--candidates**, **--llm-max-candidates** *N*]
+:   Add a new scene definition. *N* is the maximum number of distinct rewrites requested from the LLM; `0` disables LLM processing for the scene.
 
 **scene edit** *ID* [*OPTIONS*]
 :   Modify an existing scene configuration.

--- a/data/man/zh_CN/vinput-config.5
+++ b/data/man/zh_CN/vinput-config.5
@@ -125,6 +125,11 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
 .TP
 \f[B]context_lines\f[R] (\f[I]整数\f[R])
 发送给 LLM 的历史上下文行数（\f[CR]0\f[R] 表示不附带上下文）。
+.TP
+\f[B]candidate_count\f[R] (\f[I]整数\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
+向 LLM 请求改写候选的最大数量（设为 \f[CR]0\f[R] 表示不调用
+LLM）。改写结果与原始识别文本自动保序去重。去重后若只有单一结果直接自动上屏；若有不同候选则弹出菜单，默认聚焦
+LLM 最佳改写，原始文本保留为保底选项（选项 1）。
 .SH VINPUT.CONF 结构 (FCITX5 插件配置)
 Fcitx5 插件的配置文件为 INI 格式，位于
 \f[I]\(ti/.config/fcitx5/conf/vinput.conf\f[R]。

--- a/data/man/zh_CN/vinput-config.5
+++ b/data/man/zh_CN/vinput-config.5
@@ -104,7 +104,7 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
   \(dqdefinitions\(dq: [
     {
       \(dqid\(dq: \(dq__raw__\(dq,
-      \(dqllm_max_candidates\(dq: 0
+      \(dqcount\(dq: 0
     },
     {
       \(dqid\(dq: \(dqdefault\(dq,
@@ -113,7 +113,7 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
       \(dqprovider_id\(dq: \(dqgroq\(dq,
       \(dqmodel\(dq: \(dqllama\-3.3\-70b\-versatile\(dq,
       \(dqcontext_lines\(dq: 3,
-      \(dqllm_max_candidates\(dq: 5
+      \(dqcount\(dq: 5
     }
   ]
 }
@@ -126,7 +126,7 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
 \f[B]context_lines\f[R] (\f[I]整数\f[R])
 发送给 LLM 的历史上下文行数（\f[CR]0\f[R] 表示不附带上下文）。
 .TP
-\f[B]llm_max_candidates\f[R] (\f[I]整数\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
+\f[B]count\f[R] (\f[I]整数\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
 向 LLM 请求改写候选的最大数量（设为 \f[CR]0\f[R] 表示不调用
 LLM）。改写结果与原始识别文本自动保序去重。去重后若只有单一结果直接自动上屏；若有不同候选则弹出菜单，默认聚焦
 LLM 最佳改写，原始文本保留为保底选项（选项 1）。

--- a/data/man/zh_CN/vinput-config.5
+++ b/data/man/zh_CN/vinput-config.5
@@ -104,7 +104,7 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
   \(dqdefinitions\(dq: [
     {
       \(dqid\(dq: \(dq__raw__\(dq,
-      \(dqcandidate_count\(dq: 0
+      \(dqllm_max_candidates\(dq: 0
     },
     {
       \(dqid\(dq: \(dqdefault\(dq,
@@ -113,7 +113,7 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
       \(dqprovider_id\(dq: \(dqgroq\(dq,
       \(dqmodel\(dq: \(dqllama\-3.3\-70b\-versatile\(dq,
       \(dqcontext_lines\(dq: 3,
-      \(dqcandidate_count\(dq: 5
+      \(dqllm_max_candidates\(dq: 5
     }
   ]
 }
@@ -126,7 +126,7 @@ PipeWire 音频采集节点名称，或 \f[CR]\(dqdefault\(dq\f[R]
 \f[B]context_lines\f[R] (\f[I]整数\f[R])
 发送给 LLM 的历史上下文行数（\f[CR]0\f[R] 表示不附带上下文）。
 .TP
-\f[B]candidate_count\f[R] (\f[I]整数\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
+\f[B]llm_max_candidates\f[R] (\f[I]整数\f[R], \f[CR]0\f[R] \- \f[CR]9\f[R])
 向 LLM 请求改写候选的最大数量（设为 \f[CR]0\f[R] 表示不调用
 LLM）。改写结果与原始识别文本自动保序去重。去重后若只有单一结果直接自动上屏；若有不同候选则弹出菜单，默认聚焦
 LLM 最佳改写，原始文本保留为保底选项（选项 1）。

--- a/data/man/zh_CN/vinput-config.5.md
+++ b/data/man/zh_CN/vinput-config.5.md
@@ -109,7 +109,7 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
   "definitions": [
     {
       "id": "__raw__",
-      "candidate_count": 0
+      "llm_max_candidates": 0
     },
     {
       "id": "default",
@@ -118,7 +118,7 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
       "provider_id": "groq",
       "model": "llama-3.3-70b-versatile",
       "context_lines": 3,
-      "candidate_count": 5
+      "llm_max_candidates": 5
     }
   ]
 }
@@ -130,7 +130,7 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
 **context_lines** (*整数*)
 :   发送给 LLM 的历史上下文行数（`0` 表示不附带上下文）。
 
-**candidate_count** (*整数*, `0` - `9`)
+**llm_max_candidates** (*整数*, `0` - `9`)
 :   向 LLM 请求改写候选的最大数量（设为 `0` 表示不调用 LLM）。改写结果与原始识别文本自动保序去重。去重后若只有单一结果直接自动上屏；若有不同候选则弹出菜单，默认聚焦 LLM 最佳改写，原始文本保留为保底选项（选项 1）。
 
 # VINPUT.CONF 结构 (FCITX5 插件配置)

--- a/data/man/zh_CN/vinput-config.5.md
+++ b/data/man/zh_CN/vinput-config.5.md
@@ -109,7 +109,7 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
   "definitions": [
     {
       "id": "__raw__",
-      "llm_max_candidates": 0
+      "count": 0
     },
     {
       "id": "default",
@@ -118,7 +118,7 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
       "provider_id": "groq",
       "model": "llama-3.3-70b-versatile",
       "context_lines": 3,
-      "llm_max_candidates": 5
+      "count": 5
     }
   ]
 }
@@ -130,7 +130,7 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
 **context_lines** (*整数*)
 :   发送给 LLM 的历史上下文行数（`0` 表示不附带上下文）。
 
-**llm_max_candidates** (*整数*, `0` - `9`)
+**count** (*整数*, `0` - `9`)
 :   向 LLM 请求改写候选的最大数量（设为 `0` 表示不调用 LLM）。改写结果与原始识别文本自动保序去重。去重后若只有单一结果直接自动上屏；若有不同候选则弹出菜单，默认聚焦 LLM 最佳改写，原始文本保留为保底选项（选项 1）。
 
 # VINPUT.CONF 结构 (FCITX5 插件配置)

--- a/data/man/zh_CN/vinput-config.5.md
+++ b/data/man/zh_CN/vinput-config.5.md
@@ -130,6 +130,9 @@ vinput-config - fcitx5-vinput 配置文件格式与选项说明
 **context_lines** (*整数*)
 :   发送给 LLM 的历史上下文行数（`0` 表示不附带上下文）。
 
+**candidate_count** (*整数*, `0` - `9`)
+:   向 LLM 请求改写候选的最大数量（设为 `0` 表示不调用 LLM）。改写结果与原始识别文本自动保序去重。去重后若只有单一结果直接自动上屏；若有不同候选则弹出菜单，默认聚焦 LLM 最佳改写，原始文本保留为保底选项（选项 1）。
+
 # VINPUT.CONF 结构 (FCITX5 插件配置)
 
 Fcitx5 插件的配置文件为 INI 格式，位于 *~/.config/fcitx5/conf/vinput.conf*。

--- a/data/man/zh_CN/vinput.1
+++ b/data/man/zh_CN/vinput.1
@@ -143,7 +143,7 @@ ASR 识别出的原始文本进行重写与润色。
 \f[B]scene list\f[R]
 列出所有已定义的场景。
 .TP
-\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-candidates\f[R], \f[B]\-\-llm\-max\-candidates\f[R] \f[I]N\f[R]]
+\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-count\f[R] \f[I]N\f[R]]
 添加新的后处理场景。\f[I]N\f[R] 表示向 LLM
 请求的不同改写结果最大数量；\f[CR]0\f[R] 表示该场景不使用 LLM。
 .TP

--- a/data/man/zh_CN/vinput.1
+++ b/data/man/zh_CN/vinput.1
@@ -143,8 +143,9 @@ ASR 识别出的原始文本进行重写与润色。
 \f[B]scene list\f[R]
 列出所有已定义的场景。
 .TP
-\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-candidates\f[R] \f[I]N\f[R]]
-添加新的后处理场景。
+\f[B]scene add\f[R] \f[B]\-\-id\f[R] \f[I]ID\f[R] [\f[B]\-l\f[R], \f[B]\-\-label\f[R] \f[I]LABEL\f[R]] [\f[B]\-t\f[R], \f[B]\-\-prompt\f[R] \f[I]PROMPT\f[R]] [\f[B]\-p\f[R], \f[B]\-\-provider\f[R] \f[I]PROVIDER_ID\f[R]] [\f[B]\-m\f[R], \f[B]\-\-model\f[R] \f[I]MODEL\f[R]] [\f[B]\-c\f[R], \f[B]\-\-candidates\f[R], \f[B]\-\-llm\-max\-candidates\f[R] \f[I]N\f[R]]
+添加新的后处理场景。\f[I]N\f[R] 表示向 LLM
+请求的不同改写结果最大数量；\f[CR]0\f[R] 表示该场景不使用 LLM。
 .TP
 \f[B]scene edit\f[R] \f[I]ID\f[R] [\f[I]选项\f[R]]
 修改已有场景配置。

--- a/data/man/zh_CN/vinput.1.md
+++ b/data/man/zh_CN/vinput.1.md
@@ -145,8 +145,8 @@ vinput - fcitx5-vinput 命令行控制与管理工具
 **scene list**
 :   列出所有已定义的场景。
 
-**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--candidates** *N*]
-:   添加新的后处理场景。
+**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--candidates**, **--llm-max-candidates** *N*]
+:   添加新的后处理场景。*N* 表示向 LLM 请求的不同改写结果最大数量；`0` 表示该场景不使用 LLM。
 
 **scene edit** *ID* [*选项*]
 :   修改已有场景配置。

--- a/data/man/zh_CN/vinput.1.md
+++ b/data/man/zh_CN/vinput.1.md
@@ -145,7 +145,7 @@ vinput - fcitx5-vinput 命令行控制与管理工具
 **scene list**
 :   列出所有已定义的场景。
 
-**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--candidates**, **--llm-max-candidates** *N*]
+**scene add** **--id** *ID* [**-l**, **--label** *LABEL*] [**-t**, **--prompt** *PROMPT*] [**-p**, **--provider** *PROVIDER_ID*] [**-m**, **--model** *MODEL*] [**-c**, **--count** *N*]
 :   添加新的后处理场景。*N* 表示向 LLM 请求的不同改写结果最大数量；`0` 表示该场景不使用 LLM。
 
 **scene edit** *ID* [*选项*]

--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -449,8 +449,8 @@
         <translation>上下文行数：</translation>
     </message>
     <message>
-        <source>Candidate Count:</source>
-        <translation>候选词数量：</translation>
+        <source>Max LLM Candidates:</source>
+        <translation>LLM 最大候选数：</translation>
     </message>
     <message>
         <source>Timeout (ms):</source>

--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -449,8 +449,8 @@
         <translation>上下文行数：</translation>
     </message>
     <message>
-        <source>Max LLM Candidates:</source>
-        <translation>LLM 最大候选数：</translation>
+        <source>Candidate Count:</source>
+        <translation>候选数量：</translation>
     </message>
     <message>
         <source>Timeout (ms):</source>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1150,3 +1150,6 @@ msgstr "禁用适配器随 daemon 自启动"
 #, c-format
 msgid "Adapter '%s' restarted."
 msgstr "Adapter '%s' 已重启。"
+
+msgid "Maximum number of LLM candidates (0 to disable LLM)"
+msgstr "LLM 候选的最大返回数量（0 表示不使用 LLM）"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1153,3 +1153,6 @@ msgstr "Adapter '%s' 已重启。"
 
 msgid "Maximum number of LLM candidates (0 to disable LLM)"
 msgstr "LLM 候选的最大返回数量（0 表示不使用 LLM）"
+
+msgid "MAX LLM CANDIDATES"
+msgstr "LLM 最大候选数"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1154,5 +1154,5 @@ msgstr "Adapter '%s' 已重启。"
 msgid "Maximum number of LLM candidates (0 to disable LLM)"
 msgstr "LLM 候选的最大返回数量（0 表示不使用 LLM）"
 
-msgid "MAX LLM CANDIDATES"
-msgstr "LLM 最大候选数"
+msgid "COUNT"
+msgstr "数量"

--- a/site/src/content/docs/scenes/index.md
+++ b/site/src/content/docs/scenes/index.md
@@ -35,7 +35,7 @@ Each scene contains:
 | `provider_id` | Bound LLM provider |
 | `model` | Model name to use |
 | `context_lines` | Number of previous text lines sent as context to the LLM |
-| `candidate_count` | Maximum rewritten candidates requested from LLM (0 to disable LLM) |
+| `llm_max_candidates` | Maximum rewritten candidates requested from LLM (0 to disable LLM) |
 
 Rewritten results are deduplicated with the raw ASR transcript. If only 1 distinct text remains (no change), it commits directly to screen; if distinct candidates exist, a selection menu is shown (focused on the primary LLM rewrite, with the raw transcript preserved at option `1`).
 
@@ -56,7 +56,7 @@ Corresponding config:
     "definitions": [
       {
         "id": "__raw__",
-        "candidate_count": 0
+        "llm_max_candidates": 0
       },
       {
         "id": "default",
@@ -65,7 +65,7 @@ Corresponding config:
         "provider_id": "groq",
         "model": "openai/gpt-oss-120b",
         "context_lines": 3,
-        "candidate_count": 5
+        "llm_max_candidates": 5
       }
     ]
   }

--- a/site/src/content/docs/scenes/index.md
+++ b/site/src/content/docs/scenes/index.md
@@ -35,7 +35,9 @@ Each scene contains:
 | `provider_id` | Bound LLM provider |
 | `model` | Model name to use |
 | `context_lines` | Number of previous text lines sent as context to the LLM |
-| `candidate_count` | Number of candidates to return |
+| `candidate_count` | Maximum rewritten candidates requested from LLM (0 to disable LLM) |
+
+Rewritten results are deduplicated with the raw ASR transcript. If only 1 distinct text remains (no change), it commits directly to screen; if distinct candidates exist, a selection menu is shown (focused on the primary LLM rewrite, with the raw transcript preserved at option `1`).
 
 LLM is only invoked when `provider_id` + `model` + `prompt` are all configured.
 

--- a/site/src/content/docs/scenes/index.md
+++ b/site/src/content/docs/scenes/index.md
@@ -35,7 +35,7 @@ Each scene contains:
 | `provider_id` | Bound LLM provider |
 | `model` | Model name to use |
 | `context_lines` | Number of previous text lines sent as context to the LLM |
-| `llm_max_candidates` | Maximum rewritten candidates requested from LLM (0 to disable LLM) |
+| `count` | Maximum rewritten candidates requested from LLM (0 to disable LLM) |
 
 Rewritten results are deduplicated with the raw ASR transcript. If only 1 distinct text remains (no change), it commits directly to screen; if distinct candidates exist, a selection menu is shown (focused on the primary LLM rewrite, with the raw transcript preserved at option `1`).
 
@@ -56,7 +56,7 @@ Corresponding config:
     "definitions": [
       {
         "id": "__raw__",
-        "llm_max_candidates": 0
+        "count": 0
       },
       {
         "id": "default",
@@ -65,7 +65,7 @@ Corresponding config:
         "provider_id": "groq",
         "model": "openai/gpt-oss-120b",
         "context_lines": 3,
-        "llm_max_candidates": 5
+        "count": 5
       }
     ]
   }

--- a/site/src/content/docs/zh-cn/scenes/index.md
+++ b/site/src/content/docs/zh-cn/scenes/index.md
@@ -35,7 +35,9 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
 | `provider_id` | 绑定的 LLM 提供商 |
 | `model` | 使用的模型名称 |
 | `context_lines` | 发送给 LLM 作为上下文的前文行数 |
-| `candidate_count` | 返回候选数量 |
+| `candidate_count` | LLM 改写候选最大数量（0 表示不使用 LLM） |
+
+改写结果会自动与原始识别文本进行保序去重。去重后若只有一个结果（未作修改）直接自动上屏；若产生不同表达则弹出候选菜单供选择（默认高亮第 2 项 LLM 润色版，按 `1` 即可随时选回 ASR 原始文本）。
 
 只有同时配置了 `provider_id` + `model` + `prompt` 的场景才会调用 LLM。
 

--- a/site/src/content/docs/zh-cn/scenes/index.md
+++ b/site/src/content/docs/zh-cn/scenes/index.md
@@ -35,7 +35,7 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
 | `provider_id` | 绑定的 LLM 提供商 |
 | `model` | 使用的模型名称 |
 | `context_lines` | 发送给 LLM 作为上下文的前文行数 |
-| `llm_max_candidates` | LLM 改写候选最大数量（0 表示不使用 LLM） |
+| `count` | LLM 改写候选最大数量（0 表示不使用 LLM） |
 
 改写结果会自动与原始识别文本进行保序去重。去重后若只有一个结果（未作修改）直接自动上屏；若产生不同表达则弹出候选菜单供选择（默认高亮第 2 项 LLM 润色版，按 `1` 即可随时选回 ASR 原始文本）。
 
@@ -56,7 +56,7 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
     "definitions": [
       {
         "id": "__raw__",
-        "llm_max_candidates": 0
+        "count": 0
       },
       {
         "id": "default",
@@ -65,7 +65,7 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
         "provider_id": "groq",
         "model": "openai/gpt-oss-120b",
         "context_lines": 3,
-        "llm_max_candidates": 5
+        "count": 5
       }
     ]
   }

--- a/site/src/content/docs/zh-cn/scenes/index.md
+++ b/site/src/content/docs/zh-cn/scenes/index.md
@@ -35,7 +35,7 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
 | `provider_id` | 绑定的 LLM 提供商 |
 | `model` | 使用的模型名称 |
 | `context_lines` | 发送给 LLM 作为上下文的前文行数 |
-| `candidate_count` | LLM 改写候选最大数量（0 表示不使用 LLM） |
+| `llm_max_candidates` | LLM 改写候选最大数量（0 表示不使用 LLM） |
 
 改写结果会自动与原始识别文本进行保序去重。去重后若只有一个结果（未作修改）直接自动上屏；若产生不同表达则弹出候选菜单供选择（默认高亮第 2 项 LLM 润色版，按 `1` 即可随时选回 ASR 原始文本）。
 
@@ -56,7 +56,7 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
     "definitions": [
       {
         "id": "__raw__",
-        "candidate_count": 0
+        "llm_max_candidates": 0
       },
       {
         "id": "default",
@@ -65,7 +65,7 @@ ASR 原始文本 → [场景 prompt + LLM] → 改写后的文本
         "provider_id": "groq",
         "model": "openai/gpt-oss-120b",
         "context_lines": 3,
-        "candidate_count": 5
+        "llm_max_candidates": 5
       }
     ]
   }

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -721,16 +721,16 @@ void VinputEngine::onRecognitionResult(fcitx::dbus::Message& msg) {
     appendContextEntry(asr_candidate->text, "asr");
   }
 
-  int llm_count = 0;
   bool commit_from_llm = false;
   for (const auto& c : payload.candidates) {
-    if (c.source == vinput::result::kSourceLlm)
-      ++llm_count;
     if (c.source == vinput::result::kSourceLlm && c.text == payload.commitText) {
       commit_from_llm = true;
     }
   }
-  if (llm_count > 1) {
+
+  // Show candidate menu when multiple distinct choices exist (e.g. LLM rewrite + raw transcript,
+  // or multiple distinct LLM rewrites). Commit directly when only 1 choice remains.
+  if (payload.candidates.size() > 1) {
     // Save command mode for result menu interaction
     result_is_command_ = is_command;
     showResultMenu(ic, payload);

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -721,16 +721,23 @@ void VinputEngine::onRecognitionResult(fcitx::dbus::Message& msg) {
     appendContextEntry(asr_candidate->text, "asr");
   }
 
+  int distinct_llm_candidate_count = 0;
   bool commit_from_llm = false;
-  for (const auto& c : payload.candidates) {
-    if (c.source == vinput::result::kSourceLlm && c.text == payload.commitText) {
+  for (const auto& candidate : payload.candidates) {
+    if (candidate.source == vinput::result::kSourceLlm) {
+      ++distinct_llm_candidate_count;
+    }
+    if (candidate.source == vinput::result::kSourceLlm && candidate.text == payload.commitText) {
       commit_from_llm = true;
     }
   }
 
-  // Show candidate menu when multiple distinct choices exist (e.g. LLM rewrite + raw transcript,
-  // or multiple distinct LLM rewrites). Commit directly when only 1 choice remains.
-  if (payload.candidates.size() > 1) {
+  // Dictation presents every distinct choice: raw is option 1 and the primary LLM rewrite is
+  // focused. Command mode keeps its existing behavior because its payload also contains the
+  // selected text and spoken command as metadata candidates.
+  const bool should_show_result_menu =
+      is_command ? distinct_llm_candidate_count > 1 : payload.candidates.size() > 1;
+  if (should_show_result_menu) {
     // Save command mode for result menu interaction
     result_is_command_ = is_command;
     showResultMenu(ic, payload);

--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -141,7 +141,7 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
               {
                 auto core_config = LoadCoreConfig();
                 const auto* cmd_scene = FindCommandScene(core_config);
-                if (!cmd_scene || cmd_scene->candidate_count <= 0) {
+                if (!cmd_scene || cmd_scene->llm_max_candidates <= 0) {
                   finishFrontendSession(ic);
                   updatePreedit(ic, CommandDisabledPreeditText());
                   pending_start_event_.reset();
@@ -242,11 +242,11 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
     hideResultMenu();
 
     if (is_command) {
-      // Check command scene has candidate_count > 0 and a valid provider
+      // Check command scene has llm_max_candidates > 0 and a valid provider
       {
         auto core_config = LoadCoreConfig();
         const auto* cmd_scene = FindCommandScene(core_config);
-        if (!cmd_scene || cmd_scene->candidate_count <= 0) {
+        if (!cmd_scene || cmd_scene->llm_max_candidates <= 0) {
           finishFrontendSession(ic);
           updatePreedit(ic, CommandDisabledPreeditText());
           keyEvent.filterAndAccept();

--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -141,7 +141,7 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
               {
                 auto core_config = LoadCoreConfig();
                 const auto* cmd_scene = FindCommandScene(core_config);
-                if (!cmd_scene || cmd_scene->llm_max_candidates <= 0) {
+                if (cmd_scene == nullptr || cmd_scene->llm_max_candidates <= 0) {
                   finishFrontendSession(ic);
                   updatePreedit(ic, CommandDisabledPreeditText());
                   pending_start_event_.reset();
@@ -246,7 +246,7 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
       {
         auto core_config = LoadCoreConfig();
         const auto* cmd_scene = FindCommandScene(core_config);
-        if (!cmd_scene || cmd_scene->llm_max_candidates <= 0) {
+        if (cmd_scene == nullptr || cmd_scene->llm_max_candidates <= 0) {
           finishFrontendSession(ic);
           updatePreedit(ic, CommandDisabledPreeditText());
           keyEvent.filterAndAccept();

--- a/src/cli/config/register_scene.cpp
+++ b/src/cli/config/register_scene.cpp
@@ -36,7 +36,8 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   add->add_option("-t,--prompt", addState->prompt, _("LLM prompt"));
   add->add_option("-p,--provider", addState->providerId, _("LLM provider id"));
   add->add_option("-m,--model", addState->model, _("LLM model id"));
-  add->add_option("-c,--candidates", addState->candidates, _("Candidate count"))
+  add->add_option("-c,--candidates", addState->candidates,
+                  _("Maximum number of LLM candidates (0 to disable LLM)"))
       ->default_val(vinput::scene::kDefaultCandidateCount);
   add->add_option("--timeout", addState->timeoutMs, _("Request timeout in milliseconds"))
       ->default_val(vinput::scene::kDefaultTimeoutMs);
@@ -95,7 +96,8 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   auto* ePmt = edit->add_option("-t,--prompt", editState->prompt, _("LLM prompt"));
   auto* ePrv = edit->add_option("-p,--provider", editState->providerId, _("LLM provider id"));
   auto* eMdl = edit->add_option("-m,--model", editState->model, _("LLM model id"));
-  auto* eCnd = edit->add_option("-c,--candidates", editState->candidates, _("Candidate count"));
+  auto* eCnd = edit->add_option("-c,--candidates", editState->candidates,
+                                _("Maximum number of LLM candidates (0 to disable LLM)"));
   auto* eTmo =
       edit->add_option("--timeout", editState->timeoutMs, _("Request timeout in milliseconds"));
   auto* eCtx = edit->add_option("--context-lines", editState->contextLines,

--- a/src/cli/config/register_scene.cpp
+++ b/src/cli/config/register_scene.cpp
@@ -36,7 +36,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   add->add_option("-t,--prompt", addState->prompt, _("LLM prompt"));
   add->add_option("-p,--provider", addState->providerId, _("LLM provider id"));
   add->add_option("-m,--model", addState->model, _("LLM model id"));
-  add->add_option("-c,--count,--candidates,--max", addState->llmMaxCandidates,
+  add->add_option("-c,--count", addState->llmMaxCandidates,
                   _("Maximum number of LLM candidates (0 to disable LLM)"))
       ->default_val(vinput::scene::kDefaultLlmMaxCandidates);
   add->add_option("--timeout", addState->timeoutMs, _("Request timeout in milliseconds"))
@@ -96,7 +96,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   auto* ePmt = edit->add_option("-t,--prompt", editState->prompt, _("LLM prompt"));
   auto* ePrv = edit->add_option("-p,--provider", editState->providerId, _("LLM provider id"));
   auto* eMdl = edit->add_option("-m,--model", editState->model, _("LLM model id"));
-  auto* eCnd = edit->add_option("-c,--count,--candidates,--max", editState->llmMaxCandidates,
+  auto* eCnd = edit->add_option("-c,--count", editState->llmMaxCandidates,
                                 _("Maximum number of LLM candidates (0 to disable LLM)"));
   auto* eTmo =
       edit->add_option("--timeout", editState->timeoutMs, _("Request timeout in milliseconds"));

--- a/src/cli/config/register_scene.cpp
+++ b/src/cli/config/register_scene.cpp
@@ -25,7 +25,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
     std::string prompt;
     std::string providerId;
     std::string model;
-    int candidates = vinput::scene::kDefaultCandidateCount;
+    int llmMaxCandidates = vinput::scene::kDefaultLlmMaxCandidates;
     int timeoutMs = vinput::scene::kDefaultTimeoutMs;
     int contextLines = vinput::scene::kDefaultContextLines;
   };
@@ -36,9 +36,9 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   add->add_option("-t,--prompt", addState->prompt, _("LLM prompt"));
   add->add_option("-p,--provider", addState->providerId, _("LLM provider id"));
   add->add_option("-m,--model", addState->model, _("LLM model id"));
-  add->add_option("-c,--candidates", addState->candidates,
+  add->add_option("-c,--candidates,--llm-max-candidates", addState->llmMaxCandidates,
                   _("Maximum number of LLM candidates (0 to disable LLM)"))
-      ->default_val(vinput::scene::kDefaultCandidateCount);
+      ->default_val(vinput::scene::kDefaultLlmMaxCandidates);
   add->add_option("--timeout", addState->timeoutMs, _("Request timeout in milliseconds"))
       ->default_val(vinput::scene::kDefaultTimeoutMs);
   add->add_option("--context-lines", addState->contextLines,
@@ -47,7 +47,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   add->callback([action, addState]() {
     *action = [addState](Formatter& fmt, const CliContext& ctx) {
       return RunSceneConfigAdd(addState->id, addState->label, addState->prompt,
-                               addState->providerId, addState->model, addState->candidates,
+                               addState->providerId, addState->model, addState->llmMaxCandidates,
                                addState->timeoutMs, addState->contextLines, fmt, ctx);
     };
   });
@@ -77,14 +77,14 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
     std::string prompt;
     std::string providerId;
     std::string model;
-    int candidates = vinput::scene::kDefaultCandidateCount;
+    int llmMaxCandidates = vinput::scene::kDefaultLlmMaxCandidates;
     int timeoutMs = vinput::scene::kDefaultTimeoutMs;
     int contextLines = vinput::scene::kDefaultContextLines;
     bool hasLabel = false;
     bool hasPrompt = false;
     bool hasProvider = false;
     bool hasModel = false;
-    bool hasCandidates = false;
+    bool hasLlmMaxCandidates = false;
     bool hasTimeout = false;
     bool hasContextLines = false;
   };
@@ -96,7 +96,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   auto* ePmt = edit->add_option("-t,--prompt", editState->prompt, _("LLM prompt"));
   auto* ePrv = edit->add_option("-p,--provider", editState->providerId, _("LLM provider id"));
   auto* eMdl = edit->add_option("-m,--model", editState->model, _("LLM model id"));
-  auto* eCnd = edit->add_option("-c,--candidates", editState->candidates,
+  auto* eCnd = edit->add_option("-c,--candidates,--llm-max-candidates", editState->llmMaxCandidates,
                                 _("Maximum number of LLM candidates (0 to disable LLM)"));
   auto* eTmo =
       edit->add_option("--timeout", editState->timeoutMs, _("Request timeout in milliseconds"));
@@ -107,15 +107,16 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
     editState->hasPrompt = ePmt->count() > 0;
     editState->hasProvider = ePrv->count() > 0;
     editState->hasModel = eMdl->count() > 0;
-    editState->hasCandidates = eCnd->count() > 0;
+    editState->hasLlmMaxCandidates = eCnd->count() > 0;
     editState->hasTimeout = eTmo->count() > 0;
     editState->hasContextLines = eCtx->count() > 0;
     *action = [editState](Formatter& fmt, const CliContext& ctx) {
       return RunSceneConfigEdit(
           editState->id, editState->label, editState->prompt, editState->providerId,
-          editState->model, editState->candidates, editState->timeoutMs, editState->contextLines,
-          editState->hasLabel, editState->hasPrompt, editState->hasProvider, editState->hasModel,
-          editState->hasCandidates, editState->hasTimeout, editState->hasContextLines, fmt, ctx);
+          editState->model, editState->llmMaxCandidates, editState->timeoutMs,
+          editState->contextLines, editState->hasLabel, editState->hasPrompt,
+          editState->hasProvider, editState->hasModel, editState->hasLlmMaxCandidates,
+          editState->hasTimeout, editState->hasContextLines, fmt, ctx);
     };
   });
 }

--- a/src/cli/config/register_scene.cpp
+++ b/src/cli/config/register_scene.cpp
@@ -36,7 +36,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   add->add_option("-t,--prompt", addState->prompt, _("LLM prompt"));
   add->add_option("-p,--provider", addState->providerId, _("LLM provider id"));
   add->add_option("-m,--model", addState->model, _("LLM model id"));
-  add->add_option("-c,--candidates,--llm-max-candidates", addState->llmMaxCandidates,
+  add->add_option("-c,--count,--candidates,--max", addState->llmMaxCandidates,
                   _("Maximum number of LLM candidates (0 to disable LLM)"))
       ->default_val(vinput::scene::kDefaultLlmMaxCandidates);
   add->add_option("--timeout", addState->timeoutMs, _("Request timeout in milliseconds"))
@@ -96,7 +96,7 @@ void RegisterSceneCommands(CLI::App& app, CliAction* action) {
   auto* ePmt = edit->add_option("-t,--prompt", editState->prompt, _("LLM prompt"));
   auto* ePrv = edit->add_option("-p,--provider", editState->providerId, _("LLM provider id"));
   auto* eMdl = edit->add_option("-m,--model", editState->model, _("LLM model id"));
-  auto* eCnd = edit->add_option("-c,--candidates,--llm-max-candidates", editState->llmMaxCandidates,
+  auto* eCnd = edit->add_option("-c,--count,--candidates,--max", editState->llmMaxCandidates,
                                 _("Maximum number of LLM candidates (0 to disable LLM)"));
   auto* eTmo =
       edit->add_option("--timeout", editState->timeoutMs, _("Request timeout in milliseconds"));

--- a/src/cli/config/scene_actions.cpp
+++ b/src/cli/config/scene_actions.cpp
@@ -23,7 +23,6 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
                      {"prompt", scene.prompt},
                      {"provider_id", scene.provider_id},
                      {"model", scene.model},
-                     {"candidate_count", scene.llm_max_candidates},
                      {"llm_max_candidates", scene.llm_max_candidates},
                      {"timeout_ms", scene.timeout_ms},
                      {"context_lines", scene.context_lines},
@@ -34,8 +33,8 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
     return 0;
   }
 
-  std::vector<std::string> headers = {_("ID"),    _("LABEL"),      _("PROVIDER"),
-                                      _("MODEL"), _("CANDIDATES"), _("STATUS")};
+  std::vector<std::string> headers = {
+      _("ID"), _("LABEL"), _("PROVIDER"), _("MODEL"), _("MAX LLM CANDIDATES"), _("STATUS")};
   std::vector<std::vector<std::string>> rows;
   for (const auto& scene : scenes) {
     std::string label = vinput::scene::DisplayLabel(scene);
@@ -50,8 +49,9 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
 }
 
 int RunSceneConfigAdd(const std::string& id, const std::string& label, const std::string& prompt,
-                      const std::string& provider_id, const std::string& model, int candidate_count,
-                      int timeout_ms, int context_lines, Formatter& fmt, const CliContext& ctx) {
+                      const std::string& provider_id, const std::string& model,
+                      int llm_max_candidates, int timeout_ms, int context_lines, Formatter& fmt,
+                      const CliContext& ctx) {
   (void)ctx;
   CoreConfig config = LoadCoreConfig();
 
@@ -61,7 +61,7 @@ int RunSceneConfigAdd(const std::string& id, const std::string& label, const std
   def.prompt = vinput::str::TrimAsciiWhitespace(prompt);
   def.provider_id = vinput::str::TrimAsciiWhitespace(provider_id);
   def.model = vinput::str::TrimAsciiWhitespace(model);
-  def.llm_max_candidates = candidate_count;
+  def.llm_max_candidates = llm_max_candidates;
   def.timeout_ms = timeout_ms;
   def.context_lines = context_lines;
 
@@ -120,8 +120,8 @@ int RunSceneConfigRemove(const std::string& id, bool force, Formatter& fmt, cons
 
 int RunSceneConfigEdit(const std::string& id, const std::string& label, const std::string& prompt,
                        const std::string& provider_id, const std::string& model,
-                       int candidate_count, int timeout_ms, int context_lines, bool hasLabel,
-                       bool hasPrompt, bool hasProvider, bool hasModel, bool hasCandidates,
+                       int llm_max_candidates, int timeout_ms, int context_lines, bool hasLabel,
+                       bool hasPrompt, bool hasProvider, bool hasModel, bool hasLlmMaxCandidates,
                        bool hasTimeout, bool hasContextLines, Formatter& fmt,
                        const CliContext& ctx) {
   (void)ctx;
@@ -148,8 +148,8 @@ int RunSceneConfigEdit(const std::string& id, const std::string& label, const st
     updated.provider_id = vinput::str::TrimAsciiWhitespace(provider_id);
   if (hasModel)
     updated.model = vinput::str::TrimAsciiWhitespace(model);
-  if (hasCandidates)
-    updated.llm_max_candidates = candidate_count;
+  if (hasLlmMaxCandidates)
+    updated.llm_max_candidates = llm_max_candidates;
   if (hasTimeout)
     updated.timeout_ms = timeout_ms;
   if (hasContextLines)

--- a/src/cli/config/scene_actions.cpp
+++ b/src/cli/config/scene_actions.cpp
@@ -2,6 +2,7 @@
 
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
 
 #include "common/config/core_config.h"
 #include "common/i18n.h"
@@ -33,7 +34,7 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
     return 0;
   }
 
-  std::vector<std::string> headers = {
+  const std::vector<std::string> headers = {
       _("ID"), _("LABEL"), _("PROVIDER"), _("MODEL"), _("MAX LLM CANDIDATES"), _("STATUS")};
   std::vector<std::vector<std::string>> rows;
   for (const auto& scene : scenes) {
@@ -140,20 +141,27 @@ int RunSceneConfigEdit(const std::string& id, const std::string& label, const st
   }
 
   vinput::scene::Definition updated = *existing;
-  if (hasLabel)
+  if (hasLabel) {
     updated.label = vinput::str::TrimAsciiWhitespace(label);
-  if (hasPrompt)
+  }
+  if (hasPrompt) {
     updated.prompt = vinput::str::TrimAsciiWhitespace(prompt);
-  if (hasProvider)
+  }
+  if (hasProvider) {
     updated.provider_id = vinput::str::TrimAsciiWhitespace(provider_id);
-  if (hasModel)
+  }
+  if (hasModel) {
     updated.model = vinput::str::TrimAsciiWhitespace(model);
-  if (hasLlmMaxCandidates)
+  }
+  if (hasLlmMaxCandidates) {
     updated.llm_max_candidates = llm_max_candidates;
-  if (hasTimeout)
+  }
+  if (hasTimeout) {
     updated.timeout_ms = timeout_ms;
-  if (hasContextLines)
+  }
+  if (hasContextLines) {
     updated.context_lines = context_lines;
+  }
 
   vinput::scene::Config scene_config = ToSceneConfig(config.scenes);
   std::string error;
@@ -163,8 +171,9 @@ int RunSceneConfigEdit(const std::string& id, const std::string& label, const st
   }
   FromSceneConfig(config.scenes, scene_config);
 
-  if (!SaveConfigOrFail(config, fmt))
+  if (!SaveConfigOrFail(config, fmt)) {
     return 1;
+  }
 
   fmt.PrintSuccess(vinput::str::FmtStr(_("Scene '%s' updated."), id));
   return 0;

--- a/src/cli/config/scene_actions.cpp
+++ b/src/cli/config/scene_actions.cpp
@@ -24,7 +24,7 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
                      {"prompt", scene.prompt},
                      {"provider_id", scene.provider_id},
                      {"model", scene.model},
-                     {"llm_max_candidates", scene.llm_max_candidates},
+                     {"count", scene.llm_max_candidates},
                      {"timeout_ms", scene.timeout_ms},
                      {"context_lines", scene.context_lines},
                      {"builtin", scene.builtin},
@@ -34,8 +34,8 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
     return 0;
   }
 
-  const std::vector<std::string> headers = {
-      _("ID"), _("LABEL"), _("PROVIDER"), _("MODEL"), _("MAX LLM CANDIDATES"), _("STATUS")};
+  const std::vector<std::string> headers = {_("ID"),    _("LABEL"), _("PROVIDER"),
+                                            _("MODEL"), _("COUNT"), _("STATUS")};
   std::vector<std::vector<std::string>> rows;
   for (const auto& scene : scenes) {
     std::string label = vinput::scene::DisplayLabel(scene);

--- a/src/cli/config/scene_actions.cpp
+++ b/src/cli/config/scene_actions.cpp
@@ -22,7 +22,8 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
                      {"prompt", scene.prompt},
                      {"provider_id", scene.provider_id},
                      {"model", scene.model},
-                     {"candidate_count", scene.candidate_count},
+                     {"candidate_count", scene.llm_max_candidates},
+                     {"llm_max_candidates", scene.llm_max_candidates},
                      {"timeout_ms", scene.timeout_ms},
                      {"context_lines", scene.context_lines},
                      {"builtin", scene.builtin},
@@ -41,7 +42,7 @@ int RunSceneConfigList(Formatter& fmt, const CliContext& ctx) {
     std::string provider = scene.provider_id.empty() ? "-" : scene.provider_id;
     std::string model = scene.model.empty() ? "-" : scene.model;
     rows.push_back(
-        {scene.id, label, provider, model, std::to_string(scene.candidate_count), status});
+        {scene.id, label, provider, model, std::to_string(scene.llm_max_candidates), status});
   }
   fmt.PrintTable(headers, rows);
   return 0;
@@ -59,7 +60,7 @@ int RunSceneConfigAdd(const std::string& id, const std::string& label, const std
   def.prompt = vinput::str::TrimAsciiWhitespace(prompt);
   def.provider_id = vinput::str::TrimAsciiWhitespace(provider_id);
   def.model = vinput::str::TrimAsciiWhitespace(model);
-  def.candidate_count = candidate_count;
+  def.llm_max_candidates = candidate_count;
   def.timeout_ms = timeout_ms;
   def.context_lines = context_lines;
 
@@ -147,7 +148,7 @@ int RunSceneConfigEdit(const std::string& id, const std::string& label, const st
   if (hasModel)
     updated.model = vinput::str::TrimAsciiWhitespace(model);
   if (hasCandidates)
-    updated.candidate_count = candidate_count;
+    updated.llm_max_candidates = candidate_count;
   if (hasTimeout)
     updated.timeout_ms = timeout_ms;
   if (hasContextLines)

--- a/src/cli/config/scene_actions.cpp
+++ b/src/cli/config/scene_actions.cpp
@@ -1,6 +1,7 @@
 #include "cli/config/scene_actions.h"
 
 #include <nlohmann/json.hpp>
+#include <string>
 
 #include "common/config/core_config.h"
 #include "common/i18n.h"

--- a/src/cli/config/scene_actions.h
+++ b/src/cli/config/scene_actions.h
@@ -7,13 +7,14 @@
 
 int RunSceneConfigList(Formatter& fmt, const CliContext& ctx);
 int RunSceneConfigAdd(const std::string& id, const std::string& label, const std::string& prompt,
-                      const std::string& provider_id, const std::string& model, int candidate_count,
-                      int timeout_ms, int context_lines, Formatter& fmt, const CliContext& ctx);
+                      const std::string& provider_id, const std::string& model,
+                      int llm_max_candidates, int timeout_ms, int context_lines, Formatter& fmt,
+                      const CliContext& ctx);
 int RunSceneConfigUse(const std::string& id, Formatter& fmt, const CliContext& ctx);
 int RunSceneConfigRemove(const std::string& id, bool force, Formatter& fmt, const CliContext& ctx);
 int RunSceneConfigEdit(const std::string& id, const std::string& label, const std::string& prompt,
                        const std::string& provider_id, const std::string& model,
-                       int candidate_count, int timeout_ms, int context_lines, bool hasLabel,
-                       bool hasPrompt, bool hasProvider, bool hasModel, bool hasCandidates,
+                       int llm_max_candidates, int timeout_ms, int context_lines, bool hasLabel,
+                       bool hasPrompt, bool hasProvider, bool hasModel, bool hasLlmMaxCandidates,
                        bool hasTimeout, bool hasContextLines, Formatter& fmt,
                        const CliContext& ctx);

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -191,8 +191,8 @@ void to_json(json& j, const Definition& d) {
   if (!d.model.empty()) {
     j["model"] = d.model;
   }
-  if (d.llm_max_candidates != vinput::scene::kDefaultCandidateCount) {
-    j["candidate_count"] = d.llm_max_candidates;
+  if (d.llm_max_candidates != vinput::scene::kDefaultLlmMaxCandidates) {
+    j["llm_max_candidates"] = d.llm_max_candidates;
   }
   if (d.timeout_ms != vinput::scene::kDefaultTimeoutMs) {
     j["timeout_ms"] = d.timeout_ms;
@@ -209,9 +209,10 @@ void from_json(const json& j, Definition& d) {
   d.provider_id = j.value("provider_id", std::string{});
   d.model = j.value("model", std::string{});
   if (j.contains("llm_max_candidates")) {
-    d.llm_max_candidates = j.value("llm_max_candidates", vinput::scene::kDefaultCandidateCount);
+    d.llm_max_candidates = j.value("llm_max_candidates", vinput::scene::kDefaultLlmMaxCandidates);
   } else {
-    d.llm_max_candidates = j.value("candidate_count", vinput::scene::kDefaultCandidateCount);
+    // Backward compatibility for configurations written before v2.3.14.
+    d.llm_max_candidates = j.value("candidate_count", vinput::scene::kDefaultLlmMaxCandidates);
   }
   d.timeout_ms = j.value("timeout_ms", vinput::scene::kDefaultTimeoutMs);
   d.context_lines = j.value("context_lines", vinput::scene::kDefaultContextLines);

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "common/config/core_config_types.h"
+#include "common/scene/postprocess_scene.h"
 
 using json = nlohmann::ordered_json;
 

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -192,7 +192,7 @@ void to_json(json& j, const Definition& d) {
     j["model"] = d.model;
   }
   if (d.llm_max_candidates != vinput::scene::kDefaultLlmMaxCandidates) {
-    j["llm_max_candidates"] = d.llm_max_candidates;
+    j["count"] = d.llm_max_candidates;
   }
   if (d.timeout_ms != vinput::scene::kDefaultTimeoutMs) {
     j["timeout_ms"] = d.timeout_ms;
@@ -208,8 +208,12 @@ void from_json(const json& j, Definition& d) {
   d.prompt = j.value("prompt", std::string{});
   d.provider_id = j.value("provider_id", std::string{});
   d.model = j.value("model", std::string{});
-  if (j.contains("llm_max_candidates")) {
+  if (j.contains("count")) {
+    d.llm_max_candidates = j.value("count", vinput::scene::kDefaultLlmMaxCandidates);
+  } else if (j.contains("llm_max_candidates")) {
     d.llm_max_candidates = j.value("llm_max_candidates", vinput::scene::kDefaultLlmMaxCandidates);
+  } else if (j.contains("max")) {
+    d.llm_max_candidates = j.value("max", vinput::scene::kDefaultLlmMaxCandidates);
   } else {
     // Backward compatibility for configurations written before v2.3.14.
     d.llm_max_candidates = j.value("candidate_count", vinput::scene::kDefaultLlmMaxCandidates);

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -208,16 +208,7 @@ void from_json(const json& j, Definition& d) {
   d.prompt = j.value("prompt", std::string{});
   d.provider_id = j.value("provider_id", std::string{});
   d.model = j.value("model", std::string{});
-  if (j.contains("count")) {
-    d.llm_max_candidates = j.value("count", vinput::scene::kDefaultLlmMaxCandidates);
-  } else if (j.contains("llm_max_candidates")) {
-    d.llm_max_candidates = j.value("llm_max_candidates", vinput::scene::kDefaultLlmMaxCandidates);
-  } else if (j.contains("max")) {
-    d.llm_max_candidates = j.value("max", vinput::scene::kDefaultLlmMaxCandidates);
-  } else {
-    // Backward compatibility for configurations written before v2.3.14.
-    d.llm_max_candidates = j.value("candidate_count", vinput::scene::kDefaultLlmMaxCandidates);
-  }
+  d.llm_max_candidates = j.value("count", vinput::scene::kDefaultLlmMaxCandidates);
   d.timeout_ms = j.value("timeout_ms", vinput::scene::kDefaultTimeoutMs);
   d.context_lines = j.value("context_lines", vinput::scene::kDefaultContextLines);
 }

--- a/src/common/config/core_config_json.cpp
+++ b/src/common/config/core_config_json.cpp
@@ -190,8 +190,8 @@ void to_json(json& j, const Definition& d) {
   if (!d.model.empty()) {
     j["model"] = d.model;
   }
-  if (d.candidate_count != vinput::scene::kDefaultCandidateCount) {
-    j["candidate_count"] = d.candidate_count;
+  if (d.llm_max_candidates != vinput::scene::kDefaultCandidateCount) {
+    j["candidate_count"] = d.llm_max_candidates;
   }
   if (d.timeout_ms != vinput::scene::kDefaultTimeoutMs) {
     j["timeout_ms"] = d.timeout_ms;
@@ -207,7 +207,11 @@ void from_json(const json& j, Definition& d) {
   d.prompt = j.value("prompt", std::string{});
   d.provider_id = j.value("provider_id", std::string{});
   d.model = j.value("model", std::string{});
-  d.candidate_count = j.value("candidate_count", vinput::scene::kDefaultCandidateCount);
+  if (j.contains("llm_max_candidates")) {
+    d.llm_max_candidates = j.value("llm_max_candidates", vinput::scene::kDefaultCandidateCount);
+  } else {
+    d.llm_max_candidates = j.value("candidate_count", vinput::scene::kDefaultCandidateCount);
+  }
   d.timeout_ms = j.value("timeout_ms", vinput::scene::kDefaultTimeoutMs);
   d.context_lines = j.value("context_lines", vinput::scene::kDefaultContextLines);
 }

--- a/src/common/config/core_config_normalize.cpp
+++ b/src/common/config/core_config_normalize.cpp
@@ -66,7 +66,7 @@ vinput::scene::Definition MakeBuiltinScene(std::string_view id) {
   scene.builtin = true;
   if (id == vinput::scene::kRawSceneId) {
     scene.label = std::string(vinput::scene::kRawSceneLabelKey);
-    scene.candidate_count = 0;
+    scene.llm_max_candidates = 0;
   } else if (id == vinput::scene::kCommandSceneId) {
     scene.label = std::string(vinput::scene::kCommandSceneLabelKey);
     scene.prompt = std::string(kDefaultCommandPrompt);

--- a/src/common/scene/postprocess_scene.cpp
+++ b/src/common/scene/postprocess_scene.cpp
@@ -75,7 +75,7 @@ void NormalizeDefinition(Definition* scene) {
   if (IsBuiltinSceneId(scene->id)) {
     scene->builtin = true;
   }
-  scene->candidate_count = NormalizeCandidateCount(scene->candidate_count);
+  scene->llm_max_candidates = NormalizeCandidateCount(scene->llm_max_candidates);
   if (scene->timeout_ms <= 0) {
     scene->timeout_ms = kDefaultTimeoutMs;
   }
@@ -88,7 +88,7 @@ bool ValidateDefinition(const Definition& scene, std::string* error, bool requir
   if (require_id && scene.id.empty()) {
     return SetValidationError(error, "Scene id must not be empty.");
   }
-  if (scene.candidate_count < 0) {
+  if (scene.llm_max_candidates < 0) {
     return SetValidationError(error, "Scene candidate count must be 0 or greater.");
   }
   if (scene.timeout_ms <= 0) {
@@ -163,7 +163,7 @@ bool UpdateScene(Config* config, const std::string& id, const Definition& def, s
       updated.provider_id = def.provider_id;
       updated.model = def.model;
       updated.context_lines = def.context_lines;
-      updated.candidate_count = def.candidate_count;
+      updated.llm_max_candidates = def.llm_max_candidates;
       updated.timeout_ms = def.timeout_ms;
       NormalizeDefinition(&updated);
       if (!ValidateDefinition(updated, error)) {

--- a/src/common/scene/postprocess_scene.cpp
+++ b/src/common/scene/postprocess_scene.cpp
@@ -50,14 +50,14 @@ const char* BuiltinSceneLabelFromKey(std::string_view label) {
 
 } // namespace
 
-int NormalizeCandidateCount(int candidate_count) {
-  if (candidate_count < kMinCandidateCount) {
-    return kMinCandidateCount;
+int NormalizeLlmMaxCandidates(int llm_max_candidates) {
+  if (llm_max_candidates < kMinLlmMaxCandidates) {
+    return kMinLlmMaxCandidates;
   }
-  if (candidate_count > kMaxCandidateCount) {
-    return kMaxCandidateCount;
+  if (llm_max_candidates > kMaxLlmMaxCandidates) {
+    return kMaxLlmMaxCandidates;
   }
-  return candidate_count;
+  return llm_max_candidates;
 }
 
 bool IsBuiltinSceneId(std::string_view scene_id) {
@@ -75,7 +75,7 @@ void NormalizeDefinition(Definition* scene) {
   if (IsBuiltinSceneId(scene->id)) {
     scene->builtin = true;
   }
-  scene->llm_max_candidates = NormalizeCandidateCount(scene->llm_max_candidates);
+  scene->llm_max_candidates = NormalizeLlmMaxCandidates(scene->llm_max_candidates);
   if (scene->timeout_ms <= 0) {
     scene->timeout_ms = kDefaultTimeoutMs;
   }
@@ -89,7 +89,7 @@ bool ValidateDefinition(const Definition& scene, std::string* error, bool requir
     return SetValidationError(error, "Scene id must not be empty.");
   }
   if (scene.llm_max_candidates < 0) {
-    return SetValidationError(error, "Scene candidate count must be 0 or greater.");
+    return SetValidationError(error, "Scene LLM max candidates must be 0 or greater.");
   }
   if (scene.timeout_ms <= 0) {
     return SetValidationError(error, "Scene timeout must be greater than 0.");

--- a/src/common/scene/postprocess_scene.h
+++ b/src/common/scene/postprocess_scene.h
@@ -22,7 +22,7 @@ struct Definition {
   std::string prompt;
   std::string provider_id;
   std::string model;
-  int candidate_count = kDefaultCandidateCount;
+  int llm_max_candidates = kDefaultCandidateCount;
   int timeout_ms = kDefaultTimeoutMs;
   int context_lines = kDefaultContextLines;
   bool builtin = false;

--- a/src/common/scene/postprocess_scene.h
+++ b/src/common/scene/postprocess_scene.h
@@ -6,9 +6,9 @@
 
 namespace vinput::scene {
 
-constexpr int kMinCandidateCount = 0;
-constexpr int kMaxCandidateCount = 9;
-constexpr int kDefaultCandidateCount = 1;
+constexpr int kMinLlmMaxCandidates = 0;
+constexpr int kMaxLlmMaxCandidates = 9;
+constexpr int kDefaultLlmMaxCandidates = 1;
 constexpr int kDefaultTimeoutMs = 4000;
 constexpr int kDefaultContextLines = 0;
 constexpr std::string_view kRawSceneId = "__raw__";
@@ -22,7 +22,7 @@ struct Definition {
   std::string prompt;
   std::string provider_id;
   std::string model;
-  int llm_max_candidates = kDefaultCandidateCount;
+  int llm_max_candidates = kDefaultLlmMaxCandidates;
   int timeout_ms = kDefaultTimeoutMs;
   int context_lines = kDefaultContextLines;
   bool builtin = false;
@@ -33,7 +33,7 @@ struct Config {
   std::vector<Definition> scenes;
 };
 
-int NormalizeCandidateCount(int candidate_count);
+int NormalizeLlmMaxCandidates(int llm_max_candidates);
 bool IsBuiltinSceneId(std::string_view scene_id);
 bool IsBuiltinSceneLabelKey(std::string_view label);
 void NormalizeDefinition(Definition* scene);

--- a/src/daemon/postprocess/post_processor.cpp
+++ b/src/daemon/postprocess/post_processor.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 
@@ -238,8 +239,8 @@ std::string BuildContextPrefix(int max_lines) {
   return result;
 }
 
-std::string BuildConstraintsSuffix(int candidate_count) {
-  if (candidate_count <= 0) {
+std::string BuildConstraintsSuffix(int max_llm_candidates) {
+  if (max_llm_candidates <= 0) {
     return {};
   }
   char buf[768];
@@ -249,11 +250,11 @@ std::string BuildConstraintsSuffix(int candidate_count) {
                 "- Each candidate must contain only the final rewritten text.\n"
                 "- Do not include explanations, Markdown fences, or extra keys.\n"
                 "\n\n## Format\n"
-                "Return EXACTLY %d candidate(s) in a JSON object:\n"
+                "Return up to %d distinct candidate(s) in a JSON object:\n"
                 "```json\n"
-                "{\"candidates\": [\"<string>\", \"<string>\"]}\n"
+                "{\"candidates\": [\"<string>\"]}\n"
                 "```",
-                candidate_count);
+                max_llm_candidates);
   return buf;
 }
 
@@ -282,7 +283,7 @@ void MergeExtraBody(json& request, const nlohmann::json& extra, const LlmProvide
 
 std::optional<std::vector<std::string>>
 RewriteWithOpenAiCompatible(const std::string& text, const vinput::scene::Definition& scene,
-                            const LlmProvider& provider, int candidate_count,
+                            const LlmProvider& provider, int max_llm_candidates,
                             std::string* error_out, const std::string& task_prompt = {},
                             const std::atomic<bool>* cancel_flag = nullptr,
                             std::string_view asr_var = {}, std::string_view selected_var = {}) {
@@ -320,7 +321,7 @@ RewriteWithOpenAiCompatible(const std::string& text, const vinput::scene::Defini
   }
 
   const std::string context_prefix = BuildContextPrefix(scene.context_lines);
-  const std::string constraints_suffix = BuildConstraintsSuffix(candidate_count);
+  const std::string constraints_suffix = BuildConstraintsSuffix(max_llm_candidates);
 
   // We send a single user message. The output-format constraints are appended
   // verbatim at the end regardless of interpolation, since downstream parsing
@@ -515,37 +516,44 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
     return {};
   }
 
-  const int candidate_count = vinput::scene::NormalizeCandidateCount(scene.candidate_count);
+  const int max_llm_candidates = vinput::scene::NormalizeCandidateCount(scene.llm_max_candidates);
 
   vinput::result::Payload fallback;
   AppendCandidate(fallback, normalized, vinput::result::kSourceRaw);
   fallback.commitText = normalized;
 
   const LlmProvider* provider = ResolveLlmProvider(settings, scene.provider_id);
-  if (!provider || candidate_count == 0 || scene.prompt.empty()) {
+  if (!provider || max_llm_candidates == 0 || scene.prompt.empty()) {
     return fallback;
   }
 
-  auto rewritten = RewriteWithOpenAiCompatible(normalized, scene, *provider, candidate_count,
+  auto rewritten = RewriteWithOpenAiCompatible(normalized, scene, *provider, max_llm_candidates,
                                                error_out, {}, &shutting_down_);
   if (!rewritten.has_value()) {
     return fallback;
   }
 
   vinput::result::Payload payload;
-  AppendCandidate(payload, normalized, vinput::result::kSourceRaw);
-  for (auto& text : *rewritten) {
-    AppendCandidate(payload, std::move(text), vinput::result::kSourceLlm);
-  }
+  std::set<std::string> seen;
 
-  payload.commitText = normalized;
-  for (const auto& candidate : payload.candidates) {
-    if (candidate.source == vinput::result::kSourceLlm) {
-      payload.commitText = candidate.text;
-      break;
+  AppendCandidate(payload, normalized, vinput::result::kSourceRaw);
+  seen.insert(normalized);
+
+  std::string first_llm_text;
+  for (auto& text : *rewritten) {
+    std::string trimmed = std::string(TrimAsciiWhitespace(text));
+    if (trimmed.empty()) {
+      continue;
+    }
+    if (seen.insert(trimmed).second) {
+      if (first_llm_text.empty()) {
+        first_llm_text = trimmed;
+      }
+      AppendCandidate(payload, std::move(trimmed), vinput::result::kSourceLlm);
     }
   }
 
+  payload.commitText = first_llm_text.empty() ? normalized : first_llm_text;
   return payload;
 }
 
@@ -564,11 +572,11 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
     return fallback;
   }
 
-  const int command_candidate_count =
-      vinput::scene::NormalizeCandidateCount(command_scene.candidate_count);
+  const int command_max_llm_candidates =
+      vinput::scene::NormalizeCandidateCount(command_scene.llm_max_candidates);
 
   const LlmProvider* provider = ResolveLlmProvider(settings, command_scene.provider_id);
-  if (!provider || command_candidate_count == 0) {
+  if (!provider || command_max_llm_candidates == 0) {
     return fallback;
   }
 
@@ -612,29 +620,38 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
   // substituted via {{asr}}/{{selected}} (interpolation). Pass empty text to
   // avoid double-appending.
   auto rewritten =
-      RewriteWithOpenAiCompatible("", command_scene, *provider, command_candidate_count, error_out,
-                                  task_prompt, &shutting_down_, asr_var, selected_var);
+      RewriteWithOpenAiCompatible("", command_scene, *provider, command_max_llm_candidates,
+                                  error_out, task_prompt, &shutting_down_, asr_var, selected_var);
 
   vinput::result::Payload payload;
+  std::set<std::string> seen;
+
   // 1st: original selected text (always)
   AppendCandidate(payload, selected_text, vinput::result::kSourceRaw);
-  // 2nd: ASR recognized command (always)
-  AppendCandidate(payload, normalized_asr, vinput::result::kSourceAsr);
-  // 3rd+: LLM results (if available)
+  seen.insert(selected_text);
+
+  // 2nd: ASR recognized command (always, if different from selected_text)
+  if (seen.insert(normalized_asr).second) {
+    AppendCandidate(payload, normalized_asr, vinput::result::kSourceAsr);
+  }
+
+  // 3rd+: LLM results (if available, deduplicated)
+  std::string first_llm_text;
   if (rewritten.has_value()) {
     for (auto& text : *rewritten) {
-      AppendCandidate(payload, std::move(text), vinput::result::kSourceLlm);
+      std::string trimmed = std::string(TrimAsciiWhitespace(text));
+      if (trimmed.empty()) {
+        continue;
+      }
+      if (seen.insert(trimmed).second) {
+        if (first_llm_text.empty()) {
+          first_llm_text = trimmed;
+        }
+        AppendCandidate(payload, std::move(trimmed), vinput::result::kSourceLlm);
+      }
     }
   }
 
-  // commitText is the first LLM result
-  payload.commitText = selected_text;
-  for (const auto& c : payload.candidates) {
-    if (c.source == vinput::result::kSourceLlm) {
-      payload.commitText = c.text;
-      break;
-    }
-  }
-
+  payload.commitText = first_llm_text.empty() ? selected_text : first_llm_text;
   return payload;
 }

--- a/src/daemon/postprocess/post_processor.cpp
+++ b/src/daemon/postprocess/post_processor.cpp
@@ -13,7 +13,9 @@
 #include <string>
 #include <string_view>
 
+#include "common/asr/recognition_result.h"
 #include "common/llm/defaults.h"
+#include "common/scene/postprocess_scene.h"
 #include "common/utils/debug_log.h"
 #include "common/utils/path_utils.h"
 #include "common/utils/url_utils.h"
@@ -523,7 +525,7 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
   fallback.commitText = normalized;
 
   const LlmProvider* provider = ResolveLlmProvider(settings, scene.provider_id);
-  if (!provider || max_llm_candidates == 0 || scene.prompt.empty()) {
+  if (provider == nullptr || max_llm_candidates == 0 || scene.prompt.empty()) {
     return fallback;
   }
 
@@ -576,7 +578,7 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
       vinput::scene::NormalizeCandidateCount(command_scene.llm_max_candidates);
 
   const LlmProvider* provider = ResolveLlmProvider(settings, command_scene.provider_id);
-  if (!provider || command_max_llm_candidates == 0) {
+  if (provider == nullptr || command_max_llm_candidates == 0) {
     return fallback;
   }
 

--- a/src/daemon/postprocess/post_processor.cpp
+++ b/src/daemon/postprocess/post_processor.cpp
@@ -518,7 +518,7 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
     return {};
   }
 
-  const int max_llm_candidates = vinput::scene::NormalizeCandidateCount(scene.llm_max_candidates);
+  const int max_llm_candidates = vinput::scene::NormalizeLlmMaxCandidates(scene.llm_max_candidates);
 
   vinput::result::Payload fallback;
   AppendCandidate(fallback, normalized, vinput::result::kSourceRaw);
@@ -542,6 +542,7 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
   seen.insert(normalized);
 
   std::string first_llm_text;
+  int accepted_llm_candidates = 0;
   for (auto& text : *rewritten) {
     std::string trimmed = std::string(TrimAsciiWhitespace(text));
     if (trimmed.empty()) {
@@ -552,6 +553,10 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
         first_llm_text = trimmed;
       }
       AppendCandidate(payload, std::move(trimmed), vinput::result::kSourceLlm);
+      ++accepted_llm_candidates;
+      if (accepted_llm_candidates >= max_llm_candidates) {
+        break;
+      }
     }
   }
 
@@ -575,7 +580,7 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
   }
 
   const int command_max_llm_candidates =
-      vinput::scene::NormalizeCandidateCount(command_scene.llm_max_candidates);
+      vinput::scene::NormalizeLlmMaxCandidates(command_scene.llm_max_candidates);
 
   const LlmProvider* provider = ResolveLlmProvider(settings, command_scene.provider_id);
   if (provider == nullptr || command_max_llm_candidates == 0) {
@@ -637,8 +642,9 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
     AppendCandidate(payload, normalized_asr, vinput::result::kSourceAsr);
   }
 
-  // 3rd+: LLM results (if available, deduplicated)
+  // 3rd+: LLM results (if available, deduplicated and capped)
   std::string first_llm_text;
+  int accepted_llm_candidates = 0;
   if (rewritten.has_value()) {
     for (auto& text : *rewritten) {
       std::string trimmed = std::string(TrimAsciiWhitespace(text));
@@ -650,6 +656,10 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
           first_llm_text = trimmed;
         }
         AppendCandidate(payload, std::move(trimmed), vinput::result::kSourceLlm);
+        ++accepted_llm_candidates;
+        if (accepted_llm_candidates >= command_max_llm_candidates) {
+          break;
+        }
       }
     }
   }

--- a/src/daemon/runtime/recognition_pipeline.cpp
+++ b/src/daemon/runtime/recognition_pipeline.cpp
@@ -52,7 +52,7 @@ RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& se
 
   if (order.is_command) {
     const auto* cmd_scene = FindCommandScene(settings);
-    if (cmd_scene && cmd_scene->candidate_count > 0 && !cmd_scene->provider_id.empty() &&
+    if (cmd_scene && cmd_scene->llm_max_candidates > 0 && !cmd_scene->provider_id.empty() &&
         on_enter_postprocessing) {
       on_enter_postprocessing();
     }
@@ -71,7 +71,7 @@ RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& se
   }
 
   const auto& scene = vinput::scene::Resolve(scene_config, order.scene_id);
-  if (scene.candidate_count > 0 && !scene.provider_id.empty() && !scene.prompt.empty() &&
+  if (scene.llm_max_candidates > 0 && !scene.provider_id.empty() && !scene.prompt.empty() &&
       on_enter_postprocessing) {
     on_enter_postprocessing();
   }

--- a/src/daemon/runtime/recognition_pipeline.cpp
+++ b/src/daemon/runtime/recognition_pipeline.cpp
@@ -52,8 +52,8 @@ RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& se
 
   if (order.is_command) {
     const auto* cmd_scene = FindCommandScene(settings);
-    if (cmd_scene && cmd_scene->llm_max_candidates > 0 && !cmd_scene->provider_id.empty() &&
-        on_enter_postprocessing) {
+    if (cmd_scene != nullptr && cmd_scene->llm_max_candidates > 0 &&
+        !cmd_scene->provider_id.empty() && on_enter_postprocessing) {
       on_enter_postprocessing();
     }
 

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -762,7 +762,7 @@ void LlmPage::onSceneAdd() {
   form->addRow(tr("Provider:"), comboProvider);
   form->addRow(tr("Model:"), comboModel);
   form->addRow(tr("Context Lines:"), spinContextLines);
-  form->addRow(tr("Max LLM Candidates:"), spinLlmMaxCandidates);
+  form->addRow(tr("Candidate Count:"), spinLlmMaxCandidates);
   form->addRow(tr("Timeout (ms):"), spinTimeout);
 
   auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -849,7 +849,7 @@ void LlmPage::onSceneEdit() {
   form->addRow(tr("Provider:"), comboProvider);
   form->addRow(tr("Model:"), comboModel);
   form->addRow(tr("Context Lines:"), spinContextLines);
-  form->addRow(tr("Max LLM Candidates:"), spinLlmMaxCandidates);
+  form->addRow(tr("Candidate Count:"), spinLlmMaxCandidates);
   form->addRow(tr("Timeout (ms):"), spinTimeout);
 
   auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -102,9 +102,7 @@ QPlainTextEdit* MakeExtraBodyEditor(const nlohmann::json* prefill = nullptr) {
 }
 
 constexpr int kDefaultTimeoutMs = vinput::scene::kDefaultTimeoutMs;
-constexpr int kDefaultCandidateCount = 3;
-constexpr int kMinCandidateCount = 1;
-constexpr int kMaxCandidateCount = 10;
+constexpr int kDefaultUiLlmMaxCandidates = 3;
 
 QString SceneLabelForGui(const vinput::scene::Definition& scene) {
   if (scene.id == vinput::scene::kRawSceneId || scene.label == vinput::scene::kRawSceneLabelKey)
@@ -748,9 +746,10 @@ void LlmPage::onSceneAdd() {
   spinTimeout->setSingleStep(1000);
   spinTimeout->setValue(kDefaultTimeoutMs);
   spinTimeout->setSuffix(" ms");
-  auto* spinCandidates = new QSpinBox();
-  spinCandidates->setRange(kMinCandidateCount, kMaxCandidateCount);
-  spinCandidates->setValue(kDefaultCandidateCount);
+  auto* spinLlmMaxCandidates = new QSpinBox();
+  spinLlmMaxCandidates->setRange(vinput::scene::kMinLlmMaxCandidates,
+                                 vinput::scene::kMaxLlmMaxCandidates);
+  spinLlmMaxCandidates->setValue(kDefaultUiLlmMaxCandidates);
   auto* spinContextLines = new QSpinBox();
   spinContextLines->setRange(0, 9999);
   spinContextLines->setValue(vinput::scene::kDefaultContextLines);
@@ -763,7 +762,7 @@ void LlmPage::onSceneAdd() {
   form->addRow(tr("Provider:"), comboProvider);
   form->addRow(tr("Model:"), comboModel);
   form->addRow(tr("Context Lines:"), spinContextLines);
-  form->addRow(tr("Candidate Count:"), spinCandidates);
+  form->addRow(tr("Max LLM Candidates:"), spinLlmMaxCandidates);
   form->addRow(tr("Timeout (ms):"), spinTimeout);
 
   auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -784,7 +783,7 @@ void LlmPage::onSceneAdd() {
   def.provider_id = comboProvider->currentText().trimmed().toStdString();
   def.model = comboModel->currentText().trimmed().toStdString();
   def.context_lines = spinContextLines->value();
-  def.llm_max_candidates = spinCandidates->value();
+  def.llm_max_candidates = spinLlmMaxCandidates->value();
   def.timeout_ms = spinTimeout->value();
 
   CoreConfig config = ConfigManager::Get().Load();
@@ -833,9 +832,10 @@ void LlmPage::onSceneEdit() {
   spinTimeout->setSingleStep(1000);
   spinTimeout->setValue(found->timeout_ms);
   spinTimeout->setSuffix(" ms");
-  auto* spinCandidates = new QSpinBox();
-  spinCandidates->setRange(kMinCandidateCount, kMaxCandidateCount);
-  spinCandidates->setValue(found->llm_max_candidates);
+  auto* spinLlmMaxCandidates = new QSpinBox();
+  spinLlmMaxCandidates->setRange(vinput::scene::kMinLlmMaxCandidates,
+                                 vinput::scene::kMaxLlmMaxCandidates);
+  spinLlmMaxCandidates->setValue(found->llm_max_candidates);
   auto* spinContextLines = new QSpinBox();
   spinContextLines->setRange(0, 9999);
   spinContextLines->setValue(found->context_lines);
@@ -849,7 +849,7 @@ void LlmPage::onSceneEdit() {
   form->addRow(tr("Provider:"), comboProvider);
   form->addRow(tr("Model:"), comboModel);
   form->addRow(tr("Context Lines:"), spinContextLines);
-  form->addRow(tr("Candidate Count:"), spinCandidates);
+  form->addRow(tr("Max LLM Candidates:"), spinLlmMaxCandidates);
   form->addRow(tr("Timeout (ms):"), spinTimeout);
 
   auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -869,7 +869,7 @@ void LlmPage::onSceneEdit() {
   def.provider_id = comboProvider->currentText().trimmed().toStdString();
   def.model = comboModel->currentText().trimmed().toStdString();
   def.context_lines = spinContextLines->value();
-  def.llm_max_candidates = spinCandidates->value();
+  def.llm_max_candidates = spinLlmMaxCandidates->value();
   def.timeout_ms = spinTimeout->value();
 
   std::string err;

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -784,7 +784,7 @@ void LlmPage::onSceneAdd() {
   def.provider_id = comboProvider->currentText().trimmed().toStdString();
   def.model = comboModel->currentText().trimmed().toStdString();
   def.context_lines = spinContextLines->value();
-  def.candidate_count = spinCandidates->value();
+  def.llm_max_candidates = spinCandidates->value();
   def.timeout_ms = spinTimeout->value();
 
   CoreConfig config = ConfigManager::Get().Load();
@@ -835,7 +835,7 @@ void LlmPage::onSceneEdit() {
   spinTimeout->setSuffix(" ms");
   auto* spinCandidates = new QSpinBox();
   spinCandidates->setRange(kMinCandidateCount, kMaxCandidateCount);
-  spinCandidates->setValue(found->candidate_count);
+  spinCandidates->setValue(found->llm_max_candidates);
   auto* spinContextLines = new QSpinBox();
   spinContextLines->setRange(0, 9999);
   spinContextLines->setValue(found->context_lines);
@@ -869,7 +869,7 @@ void LlmPage::onSceneEdit() {
   def.provider_id = comboProvider->currentText().trimmed().toStdString();
   def.model = comboModel->currentText().trimmed().toStdString();
   def.context_lines = spinContextLines->value();
-  def.candidate_count = spinCandidates->value();
+  def.llm_max_candidates = spinCandidates->value();
   def.timeout_ms = spinTimeout->value();
 
   std::string err;


### PR DESCRIPTION
Closes #140

### Implementation Tasks
- [x] 1. Disambiguate candidate count semantics to max LLM candidates across core structs and JSON
- [x] 2. Daemon post-processor: order-preserving deduplication, always keep raw, prompt 'up to N distinct'
- [x] 3. Addon result menu: pop up when distinct candidates > 1, default cursor on primary LLM rewrite
- [x] 4. Align CLI, GUI, man pages, and docs with max LLM candidate semantics
- [x] 5. Quality gate, formatting, and i18n checks