### PR TITLE
chore: clarify 2.3.14 notification migration details

### DIFF
--- a/data/man/en/vinput-config.5
+++ b/data/man/en/vinput-config.5
@@ -146,7 +146,7 @@ The Fcitx5 addon configuration file is stored in INI format at
 TriggerMode=Both
 TriggerKey=Alt_R
 CommandKeys=Control_R
-SceneMenuKey=Shift_R
+MenuKey=Shift_R
 PagePrevKeys=Page_Up,KP_Page_Up
 PageNextKeys=Page_Down,KP_Page_Down
 MaxStreamingDisplayWidth=60
@@ -164,8 +164,10 @@ Keys used to trigger voice recording (default: Right Alt).
 Keys used to record a voice command on selected text (default: Right
 Control).
 .TP
-\f[B]SceneMenuKey\f[R] (\f[I]key list\f[R])
+\f[B]MenuKey\f[R] (\f[I]key list\f[R])
 Keys used to open the unified command palette (default: Right Shift).
+This replaces the old \f[CR]SceneMenuKey\f[R]; \f[CR]AsrMenuKey\f[R] was
+removed.
 .TP
 \f[B]MaxStreamingDisplayWidth\f[R] (\f[I]integer\f[R], \f[CR]0\f[R] \- \f[CR]500\f[R])
 Maximum visual column width for live streaming recognition preview.

--- a/data/man/en/vinput-config.5.md
+++ b/data/man/en/vinput-config.5.md
@@ -142,7 +142,7 @@ The Fcitx5 addon configuration file is stored in INI format at *~/.config/fcitx5
 TriggerMode=Both
 TriggerKey=Alt_R
 CommandKeys=Control_R
-SceneMenuKey=Shift_R
+MenuKey=Shift_R
 PagePrevKeys=Page_Up,KP_Page_Up
 PageNextKeys=Page_Down,KP_Page_Down
 MaxStreamingDisplayWidth=60
@@ -157,8 +157,8 @@ MaxStreamingDisplayWidth=60
 **CommandKeys** (*key list*)
 :   Keys used to record a voice command on selected text (default: Right Control).
 
-**SceneMenuKey** (*key list*)
-:   Keys used to open the unified command palette (default: Right Shift).
+**MenuKey** (*key list*)
+:   Keys used to open the unified command palette (default: Right Shift). This replaces the old `SceneMenuKey`; `AsrMenuKey` was removed.
 
 **MaxStreamingDisplayWidth** (*integer*, `0` - `500`)
 :   Maximum visual column width for live streaming recognition preview. Older text is folded into 'head...tail' to keep the preedit tooltip within bounds. Set to `0` to disable folding (default: `60`).

--- a/data/man/zh_CN/vinput-config.5
+++ b/data/man/zh_CN/vinput-config.5
@@ -140,7 +140,7 @@ Fcitx5 插件的配置文件为 INI 格式，位于
 TriggerMode=Both
 TriggerKey=Alt_R
 CommandKeys=Control_R
-SceneMenuKey=Shift_R
+MenuKey=Shift_R
 PagePrevKeys=Page_Up,KP_Page_Up
 PageNextKeys=Page_Down,KP_Page_Down
 MaxStreamingDisplayWidth=60
@@ -156,8 +156,10 @@ MaxStreamingDisplayWidth=60
 \f[B]CommandKeys\f[R] (\f[I]按键列表\f[R])
 对选中文本执行划词语音指令的按键（默认：右 Control）。
 .TP
-\f[B]SceneMenuKey\f[R] (\f[I]按键列表\f[R])
-打开统一命令面板（Command Palette）的快捷键（默认：右 Shift）。
+\f[B]MenuKey\f[R] (\f[I]按键列表\f[R])
+打开统一命令面板（Command Palette）的快捷键（默认：右
+Shift）。它替代旧的 \f[CR]SceneMenuKey\f[R]；\f[CR]AsrMenuKey\f[R]
+已移除。
 .TP
 \f[B]MaxStreamingDisplayWidth\f[R] (\f[I]整数\f[R], \f[CR]0\f[R] \- \f[CR]500\f[R])
 实时流式识别预览的最大视觉显示列宽。超出时自动将较早文字折叠为\(lq句首...句尾\(rq。设为

--- a/data/man/zh_CN/vinput-config.5.md
+++ b/data/man/zh_CN/vinput-config.5.md
@@ -142,7 +142,7 @@ Fcitx5 插件的配置文件为 INI 格式，位于 *~/.config/fcitx5/conf/vinpu
 TriggerMode=Both
 TriggerKey=Alt_R
 CommandKeys=Control_R
-SceneMenuKey=Shift_R
+MenuKey=Shift_R
 PagePrevKeys=Page_Up,KP_Page_Up
 PageNextKeys=Page_Down,KP_Page_Down
 MaxStreamingDisplayWidth=60
@@ -157,8 +157,8 @@ MaxStreamingDisplayWidth=60
 **CommandKeys** (*按键列表*)
 :   对选中文本执行划词语音指令的按键（默认：右 Control）。
 
-**SceneMenuKey** (*按键列表*)
-:   打开统一命令面板（Command Palette）的快捷键（默认：右 Shift）。
+**MenuKey** (*按键列表*)
+:   打开统一命令面板（Command Palette）的快捷键（默认：右 Shift）。它替代旧的 `SceneMenuKey`；`AsrMenuKey` 已移除。
 
 **MaxStreamingDisplayWidth** (*整数*, `0` - `500`)
 :   实时流式识别预览的最大视觉显示列宽。超出时自动将较早文字折叠为“句首...句尾”。设为 `0` 则禁用折叠（默认：`60`）。

--- a/notification.json
+++ b/notification.json
@@ -1,13 +1,13 @@
 {
-  "id": 13,
-  "timestamp": 1788591340,
+  "id": 14,
+  "timestamp": 1788604956,
   "title": {
-    "en_US": "Vinput 2.3.14 — Breaking Migration: Unified Command Palette & Config Cleanup",
-    "zh_CN": "Vinput 2.3.14 — 重要兼容性变更：统一命令面板与配置迁移"
+    "en_US": "Vinput 2.3.14 — Breaking changes: exact config/key migrations",
+    "zh_CN": "Vinput 2.3.14 — 破坏性变更：配置项和快捷键迁移说明"
   },
   "text": {
-    "en_US": "Important breaking/migration notes: Vinput 2.3.14 replaces the legacy F8 ASR menu with the Shift_R Unified Command Palette and removes the old AsrMenuKey/F8-specific configuration; scene candidate settings are normalized to count; LLM candidates now keep the raw transcript as option 1 and deduplicate processed candidates in order. After upgrading, open the GUI and click Save Settings once, or run vinput init -f, to sync your config. If you customized F8, candidate counts, or scene workflows, migrate them to the new /model, /asr, /scene, and /proc commands.",
-    "zh_CN": "重要兼容性/迁移提示：Vinput 2.3.14 将旧 F8 ASR 菜单替换为 Shift_R 统一命令面板，并移除旧的 AsrMenuKey/F8 独立配置；场景候选配置统一收敛为 count；LLM 候选现在固定保留原始识别文本为选项 1，并对后处理候选做保序去重。升级后请在 GUI 点击一次『保存设置』，或运行 vinput init -f 同步配置。若你曾自定义 F8、候选数量或场景工作流，请迁移到新的 /model、/asr、/scene、/proc 命令。"
+    "en_US": "Please read: 2.3.14 removes/renames old config keys.\n\n1) Fcitx addon keys: BEFORE there were two menu keys: AsrMenuKey=F8 opened the ASR provider/model menu, and SceneMenuKey=Shift_R opened the scene/postprocess menu. AFTER both old menu-key config names are gone for the unified menu path: AsrMenuKey is removed, and SceneMenuKey is renamed to MenuKey. MenuKey defaults to Shift_R and opens one Command Palette. ASR switching moved to /asr inside that palette; scenes to /scene; command models to /model; adapter processes to /proc. Old AsrMenuKey/SceneMenuKey entries are obsolete for the new palette; use the default Right Shift MenuKey after upgrade.\n\n2) Scene JSON: BEFORE scene definitions stored candidate_count. AFTER the field is count. count means maximum LLM rewrite candidates; count=0 disables LLM rewriting for that scene. The raw ASR transcript is now preserved separately as option 1 when a candidate menu is shown, so count is not the total number of displayed options including raw text. Migration: click GUI Save Settings once or run vinput init -f; manual JSON/scripts should rename candidate_count to count.\n\n3) Lite packages: BEFORE most installs were full/local-ASR capable. AFTER full and lite are separate variants. fcitx5-vinput-lite* is built with local ASR disabled: no sherpa-onnx/ONNX runtime, no local model download/switch command, and no local hotword/VAD workflow. If your config selects sherpa-onnx, install the full fcitx5-vinput package or switch /asr to a cloud provider.",
+    "zh_CN": "请注意：2.3.14 移除/重命名了几个旧配置项。\n\n1）Fcitx 插件快捷键：以前有两个菜单键：AsrMenuKey=F8 打开 ASR 服务商/模型菜单，SceneMenuKey=Shift_R 打开场景/后处理菜单。现在统一菜单路径下这两个旧配置名都不用了：AsrMenuKey 已移除，SceneMenuKey 重命名为 MenuKey。MenuKey 默认就是右 Shift，用来打开统一命令面板。切 ASR/模型改到面板里的 /asr；切场景是 /scene；切划词指令模型是 /model；启停适配器进程是 /proc。旧的 AsrMenuKey/SceneMenuKey 条目对新命令面板已过时；升级后使用默认的右 Shift MenuKey 入口即可。\n\n2）场景 JSON：以前 scene definition 里写 candidate_count；现在字段改成 count。count 表示最多请求多少个 LLM 改写候选，count=0 表示该场景关闭 LLM 改写。出现候选菜单时，原始 ASR 文本现在会单独固定保留为 1 号选项，所以 count 不是「包含原文在内的显示选项总数」。迁移方式：GUI 里点一次「保存设置」或运行 vinput init -f；手写 JSON/脚本请把 candidate_count 改成 count。\n\n3）Lite 发行版：以前大多数安装默认都是完整版/可用本地 ASR；现在正式拆成 full 和 lite 两类。fcitx5-vinput-lite* 是关闭本地 ASR 的构建：不带 sherpa-onnx/ONNX 运行时，不提供本地模型下载/切换命令，也没有本地热词/VAD 流程。如果你的配置还选着 sherpa-onnx，请安装完整版 fcitx5-vinput，或用 /asr 切到云端服务商。"
   },
   "url": "https://github.com/xifan2333/fcitx5-vinput/releases/tag/v2.3.14"
 }

--- a/src/addon/core/vinput.cpp
+++ b/src/addon/core/vinput.cpp
@@ -203,7 +203,7 @@ void VinputEngine::setConfig(const fcitx::RawConfig& rawConfig) {
 void VinputEngine::applySettings() {
   trigger_keys_ = config_.triggerKeys.value();
   command_keys_ = config_.commandKeys.value();
-  palette_menu_keys_ = config_.sceneMenuKeys.value();
+  menu_keys_ = config_.menuKeys.value();
   page_prev_keys_ = config_.pagePrevKeys.value();
   page_next_keys_ = config_.pageNextKeys.value();
   trigger_mode_ = config_.triggerMode.value();

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -132,7 +132,7 @@ private:
   fcitx::InputContext* result_menu_ic_ = nullptr;
   fcitx::KeyList trigger_keys_{fcitx::Key(FcitxKey_Alt_R)};
   fcitx::KeyList command_keys_{fcitx::Key(FcitxKey_Control_R)};
-  fcitx::KeyList palette_menu_keys_{fcitx::Key(FcitxKey_Shift_R)};
+  fcitx::KeyList menu_keys_{fcitx::Key(FcitxKey_Shift_R)};
   fcitx::KeyList page_prev_keys_{
       fcitx::Key(FcitxKey_Page_Up),
       fcitx::Key(FcitxKey_KP_Page_Up),

--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -50,13 +50,13 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
     return;
   }
 
-  if (!session_ && keyEvent.key().checkKeyList(palette_menu_keys_) && !keyEvent.isRelease()) {
+  if (!session_ && keyEvent.key().checkKeyList(menu_keys_) && !keyEvent.isRelease()) {
     showPaletteMenu(keyEvent.inputContext());
     keyEvent.filterAndAccept();
     return;
   }
 
-  if (keyEvent.key().checkKeyList(palette_menu_keys_) && keyEvent.isRelease()) {
+  if (keyEvent.key().checkKeyList(menu_keys_) && keyEvent.isRelease()) {
     keyEvent.filterAndAccept();
     return;
   }

--- a/src/addon/menu/vinput_menu.cpp
+++ b/src/addon/menu/vinput_menu.cpp
@@ -794,7 +794,7 @@ bool VinputEngine::handlePaletteMenuKeyEvent(fcitx::KeyEvent& keyEvent) {
   auto* cursor_list = candidate_list ? candidate_list->toCursorMovable() : nullptr;
   const auto normalized_key = keyEvent.key().normalize();
   const bool printable_filter_input = IsPrintableMenuInput(keyEvent.key());
-  const bool handled_key = keyEvent.key().checkKeyList(palette_menu_keys_) ||
+  const bool handled_key = keyEvent.key().checkKeyList(menu_keys_) ||
                            IsPagePrevKey(keyEvent.key()) || IsPageNextKey(keyEvent.key()) ||
                            keyEvent.key().digitSelection() >= 0 || IsBackspaceKey(keyEvent.key()) ||
                            IsUpKey(keyEvent.key()) || IsDownKey(keyEvent.key()) ||
@@ -814,7 +814,7 @@ bool VinputEngine::handlePaletteMenuKeyEvent(fcitx::KeyEvent& keyEvent) {
     return false;
   }
 
-  if (keyEvent.key().checkKeyList(palette_menu_keys_)) {
+  if (keyEvent.key().checkKeyList(menu_keys_)) {
     hidePaletteMenu();
     keyEvent.filterAndAccept();
     return true;

--- a/src/common/config/vinput_config.cpp
+++ b/src/common/config/vinput_config.cpp
@@ -15,7 +15,7 @@ fcitx::ListConstrain<fcitx::KeyConstrain> TriggerKeyListConstrain() {
   });
 }
 
-fcitx::ListConstrain<fcitx::KeyConstrain> SceneMenuKeyListConstrain() {
+fcitx::ListConstrain<fcitx::KeyConstrain> MenuKeyListConstrain() {
   return fcitx::KeyListConstrain(fcitx::KeyConstrainFlags{
       fcitx::KeyConstrainFlag::AllowModifierOnly,
       fcitx::KeyConstrainFlag::AllowModifierLess,
@@ -55,11 +55,11 @@ std::string CommandKeysTooltip() {
            "Right Control.");
 }
 
-std::string SceneMenuKeyLabel() {
+std::string MenuKeyLabel() {
   return _("Command Palette Keys");
 }
 
-std::string SceneMenuKeyTooltip() {
+std::string MenuKeyTooltip() {
   return _("Configure one or more keys to open the unified command palette (/model, /asr, /scene, "
            "/proc). The default is Right Shift.");
 }
@@ -106,9 +106,8 @@ VinputConfig::VinputConfig()
                   TriggerKeyListConstrain(), {}, fcitx::ToolTipAnnotation(TriggerKeyTooltip())),
       commandKeys(this, "CommandKeys", CommandKeysLabel(), {fcitx::Key(FcitxKey_Control_R)},
                   TriggerKeyListConstrain(), {}, fcitx::ToolTipAnnotation(CommandKeysTooltip())),
-      sceneMenuKeys(this, "SceneMenuKey", SceneMenuKeyLabel(), {fcitx::Key(FcitxKey_Shift_R)},
-                    SceneMenuKeyListConstrain(), {},
-                    fcitx::ToolTipAnnotation(SceneMenuKeyTooltip())),
+      menuKeys(this, "MenuKey", MenuKeyLabel(), {fcitx::Key(FcitxKey_Shift_R)},
+               MenuKeyListConstrain(), {}, fcitx::ToolTipAnnotation(MenuKeyTooltip())),
       pagePrevKeys(this, "PagePrevKeys", PagePrevKeysLabel(),
                    {fcitx::Key(FcitxKey_Page_Up), fcitx::Key(FcitxKey_KP_Page_Up)},
                    TriggerKeyListConstrain(), {}, fcitx::ToolTipAnnotation(PagePrevKeysTooltip())),

--- a/src/common/config/vinput_config.cpp
+++ b/src/common/config/vinput_config.cpp
@@ -1,5 +1,6 @@
 #include "common/config/vinput_config.h"
 
+#include <fcitx-utils/keysymgen.h>
 #include <fcitx-utils/standardpath.h>
 #include <filesystem>
 #include <string>

--- a/src/common/config/vinput_config.h
+++ b/src/common/config/vinput_config.h
@@ -33,7 +33,7 @@ public:
 
   fcitx::Option<fcitx::KeyList, fcitx::ListConstrain<fcitx::KeyConstrain>,
                 fcitx::DefaultMarshaller<fcitx::KeyList>, fcitx::ToolTipAnnotation>
-      sceneMenuKeys;
+      menuKeys;
 
   fcitx::Option<fcitx::KeyList, fcitx::ListConstrain<fcitx::KeyConstrain>,
                 fcitx::DefaultMarshaller<fcitx::KeyList>, fcitx::ToolTipAnnotation>


### PR DESCRIPTION
Clarify and align Vinput 2.3.14 breaking/migration changes for the unified command palette.

### Implementation Tasks
- [x] 1. Rename the unified command palette addon config from legacy SceneMenuKey naming to MenuKey
- [x] 2. Update man pages and notification.json with explicit count/Lite/menu migration notes

- [x] 3. Fix clang-tidy direct keysym include diagnostic (verify against CI Fcitx 5.1.7 headers)

### Validation
- `mise run check:plan`
- `mise run check:changed`
- `python3 scripts/check-i18n.py`


