### PR TITLE
fix(gui): complete zh_CN translations and load Qt base translator (#159)

### DIFF
--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -1,300 +1,486 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
+<?xml version='1.0' encoding='utf-8'?>
 <TS version="2.1" language="zh_CN">
 <context>
-    <name>MainWindow</name>
+    <name>AdapterDialog</name>
     <message>
-        <source>Vinput Configuration</source>
-        <translation>Vinput 配置</translation>
-    </message>
-    <message>
-        <source>Save Settings</source>
-        <translation>保存设置</translation>
-    </message>
-    <message>
-        <source>Hotwords</source>
-        <translation>热词</translation>
-    </message>
-    <message>
-        <source>Success</source>
-        <translation>成功</translation>
-    </message>
-    <message>
-        <source>Settings saved successfully!</source>
-        <translation>设置已成功保存！</translation>
-    </message>
-    <message>
-        <source>Control</source>
-        <translation>控制</translation>
-    </message>
-    <message>
-        <source>Resources</source>
-        <translation>资源</translation>
-    </message>
-    <message>
-        <source>LLM</source>
-        <translation>LLM</translation>
-    </message>
-    <message>
-        <source>Open Config</source>
-        <translation>打开配置</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <source>Failed to save config.</source>
-        <translation>保存配置失败。</translation>
-    </message>
-    <message>
-        <source>Details</source>
-        <translation>查看详情</translation>
-    </message>
-    <message>
-        <source>Start with daemon</source>
-        <translation>随守护进程启动</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="54" />
         <source>Configure LLM Adapter</source>
         <translation>配置 LLM 适配器</translation>
     </message>
     <message>
-        <source>Adapter ID:</source>
-        <translation>适配器 ID：</translation>
-    </message>
-    <message>
-        <source>Command / Interpreter:</source>
-        <translation>命令 / 解释器：</translation>
-    </message>
-    <message>
-        <source>Args:</source>
-        <translation>参数：</translation>
-    </message>
-    <message>
-        <source>Env:</source>
-        <translation>环境变量：</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="65" />
         <source>One argument per line</source>
         <translation>每行一个参数</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="66" />
         <source>One KEY=VALUE entry per line</source>
         <translation>每行一个 KEY=VALUE 条目</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="67" />
         <source>Command or interpreter</source>
         <translation>命令或解释器</translation>
     </message>
     <message>
-        <source>Name:</source>
-        <translation>名称：</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="73" />
+        <source>Adapter ID:</source>
+        <translation>适配器 ID：</translation>
     </message>
     <message>
-        <source>Type:</source>
-        <translation>类型：</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="74" />
+        <source>Command / Interpreter:</source>
+        <translation>命令 / 解释器：</translation>
     </message>
     <message>
-        <source>Model:</source>
-        <translation>模型：</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="75" />
+        <source>Args:</source>
+        <translation>参数：</translation>
     </message>
     <message>
-        <source>Timeout (ms):</source>
-        <translation>超时（毫秒）：</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="76" />
+        <source>Env:</source>
+        <translation>环境变量：</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="78" />
+        <source>Start with daemon</source>
+        <translation>随守护进程启动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="102" />
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+</context>
+<context>
+    <name>AsrProviderDialog</name>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="107" />
         <source>local</source>
         <translation>本地</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="109" />
         <source>command</source>
         <translation>命令</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="112" />
+        <source>One argument per line</source>
+        <translation>每行一个参数</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="113" />
+        <source>One KEY=VALUE entry per line</source>
+        <translation>每行一个 KEY=VALUE 条目</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="164" />
+        <source>Name:</source>
+        <translation>名称：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="165" />
+        <source>Type:</source>
+        <translation>类型：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="166" />
+        <source>Model:</source>
+        <translation>模型：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="167" />
+        <source>Command / Interpreter:</source>
+        <translation>命令 / 解释器：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="168" />
+        <source>Args:</source>
+        <translation>参数：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="169" />
+        <source>Env:</source>
+        <translation>环境变量：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="170" />
+        <source>Timeout (ms):</source>
+        <translation>超时（毫秒）：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="187" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="207" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="219" />
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="188" />
         <source>Provider name must not be empty.</source>
         <translation>提供程序名称不能为空。</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="208" />
         <source>Command providers require a command.</source>
         <translation>命令类型的提供程序需要填写命令。</translation>
     </message>
+</context>
+<context>
+    <name>GuiHelpers</name>
     <message>
-        <source>Loading models...</source>
-        <translation>正在加载模型…</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="52" />
+        <source>Provider name must not be empty.</source>
+        <translation>提供程序名称不能为空。</translation>
     </message>
     <message>
-        <source>No models returned. You can type one manually.</source>
-        <translation>未返回任何模型，可手动输入。</translation>
-    </message>
-    <message>
-        <source>Invalid env entry &apos;%1&apos;. Use KEY=VALUE.</source>
-        <translation>无效的环境变量条目“%1”，请使用 KEY=VALUE 格式。</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="61" />
         <source>Base URL must be a valid http:// or https:// URL.</source>
         <translation>Base URL 必须是有效的 http:// 或 https:// 地址。</translation>
     </message>
     <message>
-        <source>Provider returned invalid JSON for /v1/models.</source>
-        <translation>提供程序的 /v1/models 返回了无效的 JSON。</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="80" />
+        <source>Invalid env entry '%1'. Use KEY=VALUE.</source>
+        <translation>无效的环境变量条目“%1”，请使用 KEY=VALUE 格式。</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="111" />
+        <source>No models returned. You can type one manually.</source>
+        <translation>未返回任何模型，可手动输入。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="129" />
         <source>Failed to load models. Type one manually or reselect the provider to retry.</source>
         <translation>模型加载失败，可手动输入或重新选择提供程序重试。</translation>
     </message>
     <message>
-        <source>running</source>
-        <translation>运行中</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="167" />
+        <source>Loading models...</source>
+        <translation>正在加载模型…</translation>
     </message>
     <message>
-        <source>stopped</source>
-        <translation>已停止</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="211" />
+        <source>Provider returned invalid JSON for /v1/models.</source>
+        <translation>提供程序的 /v1/models 返回了无效的 JSON。</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="33" />
+        <source>Vinput Configuration</source>
+        <translation>Vinput 配置</translation>
     </message>
     <message>
-        <source>(not set)</source>
-        <translation>（未设置）</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="52" />
+        <source>Control</source>
+        <translation>控制</translation>
     </message>
     <message>
-        <source>Raw</source>
-        <translation>原始</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="53" />
+        <source>Resources</source>
+        <translation>资源</translation>
     </message>
     <message>
-        <source>Command</source>
-        <translation>命令</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="54" />
+        <source>LLM</source>
+        <translation>LLM</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="56" />
+        <source>Hotwords</source>
+        <translation>热词</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="66" />
+        <source>Open Config</source>
+        <translation>打开配置</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="69" />
+        <source>Save Settings</source>
+        <translation>保存设置</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="132" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="139" />
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="132" />
+        <source>Failed to save config.</source>
+        <translation>保存配置失败。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="142" />
+        <source>Success</source>
+        <translation>成功</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="142" />
+        <source>Settings saved successfully!</source>
+        <translation>设置已成功保存！</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="264" />
+        <source>Details</source>
+        <translation>查看详情</translation>
     </message>
 </context>
 <context>
     <name>vinput::gui::ControlPage</name>
     <message>
-        <source>&lt;b&gt;Audio&lt;/b&gt;</source>
-        <translation>&lt;b&gt;音频&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Capture Device:</source>
-        <translation>录音设备：</translation>
-    </message>
-    <message>
-        <source>Normalize audio</source>
-        <translation>归一化音频</translation>
-    </message>
-    <message>
-        <source>Apply peak normalization to captured audio before recognition.</source>
-        <translation>在识别前对采集到的音频做峰值归一化。</translation>
-    </message>
-    <message>
-        <source>Input gain:</source>
-        <translation>输入增益：</translation>
-    </message>
-    <message>
-        <source>Microphone gain multiplier applied to captured audio.</source>
-        <translation>应用于采集音频的麦克风增益倍数。</translation>
-    </message>
-    <message>
-        <source>Trim silence (VAD)</source>
-        <translation>裁剪静音（VAD）</translation>
-    </message>
-    <message>
-        <source>Use voice activity detection to trim leading/trailing silence.</source>
-        <translation>使用语音活动检测裁剪首尾静音。</translation>
-    </message>
-    <message>
-        <source>Reduce output volume while recording</source>
-        <translation>录音时降低输出音量</translation>
-    </message>
-    <message>
-        <source>Lower the system output volume while recording, then restore it. Useful when speaker sound leaks into the microphone.</source>
-        <translation>录音时降低系统输出音量，结束后恢复。适用于外放声音被麦克风收入、干扰识别的情况。</translation>
-    </message>
-    <message>
-        <source>Output volume while recording:</source>
-        <translation>录音时的输出音量：</translation>
-    </message>
-    <message>
-        <source>Fraction of the current output volume to keep while recording.</source>
-        <translation>录音时保留的当前输出音量比例。</translation>
-    </message>
-    <message>
-        <source> %</source>
-        <translation> %</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;ASR Providers&lt;/b&gt;</source>
-        <translation>&lt;b&gt;ASR 提供商&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>移除</translation>
-    </message>
-    <message>
-        <source>Activate</source>
-        <translation>激活</translation>
-    </message>
-    <message>
-        <source>Daemon Status:</source>
-        <translation>守护进程状态：</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation>未知</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="122" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="257" />
         <source>Start</source>
         <translation>启动</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="123" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="258" />
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="124" />
+        <source>Start with daemon</source>
+        <translation>随守护进程启动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="131" />
+        <source>&lt;b&gt;Audio&lt;/b&gt;</source>
+        <translation>&lt;b&gt;音频&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="136" />
+        <source>Capture Device:</source>
+        <translation>录音设备：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="138" />
+        <source>Normalize audio</source>
+        <translation>归一化音频</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="140" />
+        <source>Apply peak normalization to captured audio before recognition.</source>
+        <translation>在识别前对采集到的音频做峰值归一化。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="147" />
+        <source>Microphone gain multiplier applied to captured audio.</source>
+        <translation>应用于采集音频的麦克风增益倍数。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="148" />
+        <source>Input gain:</source>
+        <translation>输入增益：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="151" />
+        <source>Trim silence (VAD)</source>
+        <translation>裁剪静音（VAD）</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="152" />
+        <source>Use voice activity detection to trim leading/trailing silence.</source>
+        <translation>使用语音活动检测裁剪首尾静音。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="156" />
+        <source>Reduce output volume while recording</source>
+        <translation>录音时降低输出音量</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="157" />
+        <source>Lower the system output volume while recording, then restore it. Useful when speaker sound leaks into the microphone.</source>
+        <translation>录音时降低系统输出音量，结束后恢复。适用于外放声音被麦克风收入、干扰识别的情况。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="163" />
+        <source> %</source>
+        <translation> %</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="164" />
+        <source>Fraction of the current output volume to keep while recording.</source>
+        <translation>录音时保留的当前输出音量比例。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="165" />
+        <source>Output volume while recording:</source>
+        <translation>录音时的输出音量：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="180" />
+        <source>&lt;b&gt;ASR Providers&lt;/b&gt;</source>
+        <translation>&lt;b&gt;ASR 提供商&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="188" />
+        <source>Edit</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="189" />
+        <source>Activate</source>
+        <translation>激活</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="213" />
+        <source>&lt;b&gt;Adapters&lt;/b&gt;</source>
+        <translation>&lt;b&gt;适配器&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="221" />
+        <source>Automatically start this adapter when vinput-daemon starts.</source>
+        <translation>当 vinput-daemon 启动时自动启动此适配器。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="247" />
+        <source>Daemon Status:</source>
+        <translation>守护进程状态：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="248" />
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="259" />
         <source>Restart</source>
         <translation>重启</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="394" />
+        <source>(not set)</source>
+        <translation>（未设置）</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="401" />
+        <source>configured</source>
+        <translation>已配置</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="404" />
+        <source>effective</source>
+        <translation>已生效</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="407" />
+        <source>loading</source>
+        <translation>加载中</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="410" />
+        <source>reload failed</source>
+        <translation>重载失败</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="476" />
         <source>Edit ASR Provider</source>
         <translation>编辑 ASR 提供商</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="506" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="530" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="635" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="656" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="684" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="737" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="774" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <source>Confirm</source>
-        <translation>确认</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="506" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="530" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="684" />
+        <source>Failed to save config.</source>
+        <translation>保存配置失败。</translation>
     </message>
     <message>
-        <source>Are you sure you want to remove ASR provider &apos;%1&apos;?</source>
-        <translation>确定要移除 ASR 提供商&quot;%1&quot;吗？</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="513" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="537" />
+        <source>Warning</source>
+        <translation>警告</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="514" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="538" />
+        <source>Config saved, but failed to reload ASR backend: %1</source>
+        <translation>配置已保存，但重新加载 ASR 后端失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="560" />
+        <source>running</source>
+        <translation>运行中</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="560" />
+        <source>stopped</source>
+        <translation>已停止</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="561" />
+        <source>autostart</source>
+        <translation>自启动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="561" />
+        <source>manual</source>
+        <translation>手动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="575" />
+        <source>Command: %1</source>
+        <translation>命令：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="582" />
+        <source>Args: %1</source>
+        <translation>参数：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="589" />
+        <source>Env: %1</source>
+        <translation>环境变量：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="696" />
         <source>Stopped</source>
         <translation>已停止</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="704" />
         <source>Running (Status Error: %1)</source>
         <translation>运行中（状态错误：%1）</translation>
     </message>
     <message>
-        <source>Running: %1</source>
-        <translation>运行中：%1</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="711" />
         <source>Running: %1 (loading backend)</source>
         <translation>运行中：%1（后端加载中）</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="714" />
         <source>Running: %1 (backend error)</source>
         <translation>运行中：%1（后端错误）</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="716" />
+        <source>Running: %1</source>
+        <translation>运行中：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="794" />
         <source>Additional Install Required</source>
         <translation>需要额外配置</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="795" />
         <source>Vinput requires additional Flatpak permissions. Run the following commands, then restart Fcitx5:
 
 %1</source>
@@ -302,90 +488,31 @@
 
 %1</translation>
     </message>
-    <message>
-        <source>Failed to save config.</source>
-        <translation>保存配置失败。</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation>警告</translation>
-    </message>
-    <message>
-        <source>Config saved, but failed to reload ASR backend: %1</source>
-        <translation>配置已保存，但重新加载 ASR 后端失败：%1</translation>
-    </message>
-    <message>
-        <source>configured</source>
-        <translation>已配置</translation>
-    </message>
-    <message>
-        <source>effective</source>
-        <translation>已生效</translation>
-    </message>
-    <message>
-        <source>loading</source>
-        <translation>加载中</translation>
-    </message>
-    <message>
-        <source>reload failed</source>
-        <translation>重载失败</translation>
-    </message>
-    <message>
-        <source>The local ASR provider cannot be removed.</source>
-        <translation>内置的本地语音识别不可移除。</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Adapters&lt;/b&gt;</source>
-        <translation>&lt;b&gt;适配器&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Start with daemon</source>
-        <translation>随守护进程启动</translation>
-    </message>
-    <message>
-        <source>Automatically start this adapter when vinput-daemon starts.</source>
-        <translation>当 vinput-daemon 启动时自动启动此适配器。</translation>
-    </message>
-    <message>
-        <source>autostart</source>
-        <translation>自启动</translation>
-    </message>
-    <message>
-        <source>manual</source>
-        <translation>手动</translation>
-    </message>
-    <message>
-        <source>Command: %1</source>
-        <translation>命令：%1</translation>
-    </message>
-    <message>
-        <source>Args: %1</source>
-        <translation>参数：%1</translation>
-    </message>
-    <message>
-        <source>Env: %1</source>
-        <translation>环境变量：%1</translation>
-    </message>
 </context>
 <context>
     <name>vinput::gui::HotwordPage</name>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="22" />
         <source>Path to hotwords file...</source>
         <translation>热词文件路径...</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="23" />
         <source>Browse...</source>
         <translation>浏览...</translation>
     </message>
     <message>
-        <source>Hotwords (one per line, optional transducer score: &quot;word:2.0&quot;):</source>
-        <translation>热词（每行一个，可选 Transducer 权重：&quot;词:2.0&quot;）：</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="29" />
+        <source>Hotwords (one per line, optional transducer score: "word:2.0"):</source>
+        <translation>热词（每行一个，可选 Transducer 权重："词:2.0"）：</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="80" />
         <source>Select Hotwords File</source>
         <translation>选择热词文件</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="81" />
         <source>Text Files (*.txt);;All Files (*)</source>
         <translation>文本文件 (*.txt);;所有文件 (*)</translation>
     </message>
@@ -393,491 +520,720 @@
 <context>
     <name>vinput::gui::LlmPage</name>
     <message>
-        <source>&lt;b&gt;Providers&lt;/b&gt;</source>
-        <translation>&lt;b&gt;提供商&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>添加</translation>
-    </message>
-    <message>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>移除</translation>
-    </message>
-    <message>
-        <source>LLM adapters are local OpenAI-compatible bridge processes. Install them from the Resources page, then manage runtime here.</source>
-        <translation>LLM 适配器是本地 OpenAI 兼容桥接进程。从资源页面安装后，可在此管理运行状态。</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>启动</translation>
-    </message>
-    <message>
-        <source>Stop</source>
-        <translation>停止</translation>
-    </message>
-    <message>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Installed Adapters&lt;/b&gt;</source>
-        <translation>&lt;b&gt;已安装适配器&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Scenes&lt;/b&gt;</source>
-        <translation>&lt;b&gt;场景&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Activate</source>
-        <translation>激活</translation>
-    </message>
-    <message>
-        <source>Command: %1</source>
-        <translation>命令：%1</translation>
-    </message>
-    <message>
-        <source>Args: %1</source>
-        <translation>参数：%1</translation>
-    </message>
-    <message>
-        <source>Env: %1</source>
-        <translation>环境变量：%1</translation>
-    </message>
-    <message>
-        <source>Add LLM Provider</source>
-        <translation>添加 LLM 提供商</translation>
-    </message>
-    <message>
-        <source>Name:</source>
-        <translation>名称：</translation>
-    </message>
-    <message>
-        <source>Base URL:</source>
-        <translation>地址：</translation>
-    </message>
-    <message>
-        <source>API Key:</source>
-        <translation>密钥：</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="81" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="89" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="343" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="354" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="366" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="418" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="438" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="473" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="498" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="504" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="599" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="611" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="660" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="701" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="723" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="808" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="813" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="897" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="902" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="928" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="933" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="952" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="958" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <source>Edit LLM Provider</source>
-        <translation>编辑 LLM 提供商</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="82" />
+        <source>Extra body must be a JSON object (e.g. {"enable_thinking": false}).</source>
+        <translation>附加请求体必须是 JSON 对象（例如 {"enable_thinking": false}）。</translation>
     </message>
     <message>
-        <source>Leave empty to keep current key</source>
-        <translation>留空保持当前密钥不变</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>确认</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to remove LLM provider &apos;%1&apos;?</source>
-        <translation>确定要移除 LLM 提供商&quot;%1&quot;吗？</translation>
-    </message>
-    <message>
-        <source>Adapter &apos;%1&apos; not found in configuration.</source>
-        <translation>配置中未找到适配器&quot;%1&quot;。</translation>
-    </message>
-    <message>
-        <source>LLM Adapter Started</source>
-        <translation>LLM 适配器已启动</translation>
-    </message>
-    <message>
-        <source>Adapter &apos;%1&apos; started.</source>
-        <translation>适配器&quot;%1&quot;已启动。</translation>
-    </message>
-    <message>
-        <source>Scenes Updated</source>
-        <translation>场景已更新</translation>
-    </message>
-    <message>
-        <source>Removed provider &apos;%1&apos; and cleared it from %2 scene(s).</source>
-        <translation>已移除提供商&quot;%1&quot;，并从 %2 个场景中清除了它的引用。</translation>
-    </message>
-    <message>
-        <source>Add Scene</source>
-        <translation>添加场景</translation>
-    </message>
-    <message>
-        <source>Edit Scene</source>
-        <translation>编辑场景</translation>
-    </message>
-    <message>
-        <source>autostart</source>
-        <translation>自启动</translation>
-    </message>
-    <message>
-        <source>manual</source>
-        <translation>手动</translation>
-    </message>
-    <message>
-        <source>Autostart: %1</source>
-        <translation>自启动：%1</translation>
-    </message>
-    <message>
-        <source>enabled</source>
-        <translation>已启用</translation>
-    </message>
-    <message>
-        <source>disabled</source>
-        <translation>已禁用</translation>
-    </message>
-    <message>
-        <source>ID:</source>
-        <translation>ID：</translation>
-    </message>
-    <message>
-        <source>Label:</source>
-        <translation>标签：</translation>
-    </message>
-    <message>
-        <source>Prompt:</source>
-        <translation>提示词：</translation>
-    </message>
-    <message>
-        <source>Provider:</source>
-        <translation>提供者：</translation>
-    </message>
-    <message>
-        <source>Model:</source>
-        <translation>模型：</translation>
-    </message>
-    <message>
-        <source>Context Lines:</source>
-        <translation>上下文行数：</translation>
-    </message>
-    <message>
-        <source>Candidate Count:</source>
-        <translation>候选数量：</translation>
-    </message>
-    <message>
-        <source>Timeout (ms):</source>
-        <translation>超时（毫秒）：</translation>
-    </message>
-    <message>
-        <source>Include raw transcript in candidate options</source>
-        <translation>在候选词选项中包含原始语音文本</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to remove scene &apos;%1&apos;?</source>
-        <translation>确定要移除场景&quot;%1&quot;吗？</translation>
-    </message>
-    <message>
-        <source>LLM provider &apos;%1&apos; already exists.</source>
-        <translation>LLM 提供者 &apos;%1&apos; 已存在。</translation>
-    </message>
-    <message>
-        <source>Failed to save config.</source>
-        <translation>保存配置失败。</translation>
-    </message>
-    <message>
-        <source>Test</source>
-        <translation>测试</translation>
-    </message>
-    <message>
-        <source>Testing...</source>
-        <translation>测试中...</translation>
-    </message>
-    <message>
-        <source>Provider &apos;%1&apos; not found.</source>
-        <translation>未找到提供商&quot;%1&quot;。</translation>
-    </message>
-    <message>
-        <source>Provider base_url is empty.</source>
-        <translation>提供商 base_url 为空。</translation>
-    </message>
-    <message>
-        <source>Test Failed</source>
-        <translation>测试失败</translation>
-    </message>
-    <message>
-        <source>Connection to &apos;%1&apos; failed:
-%2</source>
-        <translation>连接&quot;%1&quot;失败：
-%2</translation>
-    </message>
-    <message>
-        <source>Invalid response from &apos;%1&apos;.</source>
-        <translation>&quot;%1&quot;返回了无效的响应。</translation>
-    </message>
-    <message>
-        <source>Test Succeeded</source>
-        <translation>测试成功</translation>
-    </message>
-    <message>
-        <source>Connected to &apos;%1&apos;.
-Found %2 model(s).</source>
-        <translation>已连接&quot;%1&quot;。
-找到 %2 个模型。</translation>
-    </message>
-    <message>
-        <source>Extra body (JSON):</source>
-        <translation>附加请求体 (JSON)：</translation>
-    </message>
-    <message>
-        <source>Optional JSON object merged into each request body, e.g. {&quot;enable_thinking&quot;: false}</source>
-        <translation>可选的 JSON 对象，将合并进每次请求体，例如 {&quot;enable_thinking&quot;: false}</translation>
-    </message>
-    <message>
-        <source>Extra body must be a JSON object (e.g. {&quot;enable_thinking&quot;: false}).</source>
-        <translation>附加请求体必须是 JSON 对象（例如 {&quot;enable_thinking&quot;: false}）。</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="90" />
         <source>Invalid extra_body JSON: %1</source>
         <translation>extra_body JSON 无效：%1</translation>
     </message>
     <message>
-        <source>Are you sure you want to remove LLM adapter &apos;%1&apos;?</source>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="97" />
+        <source>Optional JSON object merged into each request body, e.g. {"enable_thinking": false}</source>
+        <translation>可选的 JSON 对象，将合并进每次请求体，例如 {"enable_thinking": false}</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="113" />
+        <source>Raw</source>
+        <translation>原始</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="116" />
+        <source>Command</source>
+        <translation>命令</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="162" />
+        <source>&lt;b&gt;Providers&lt;/b&gt;</source>
+        <translation>&lt;b&gt;提供商&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="168" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="214" />
+        <source>Add</source>
+        <translation>添加</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="169" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="191" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="215" />
+        <source>Edit</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="170" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="192" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="216" />
+        <source>Remove</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="171" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="536" />
+        <source>Test</source>
+        <translation>测试</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="181" />
+        <source>LLM adapters are local OpenAI-compatible bridge processes. Install them from the Resources page, then manage runtime here.</source>
+        <translation>LLM 适配器是本地 OpenAI 兼容桥接进程。从资源页面安装后，可在此管理运行状态。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="193" />
+        <source>Start</source>
+        <translation>启动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="194" />
+        <source>Stop</source>
+        <translation>停止</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="195" />
+        <source>Refresh</source>
+        <translation>刷新</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="204" />
+        <source>&lt;b&gt;Installed Adapters&lt;/b&gt;</source>
+        <translation>&lt;b&gt;已安装适配器&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="208" />
+        <source>&lt;b&gt;Scenes&lt;/b&gt;</source>
+        <translation>&lt;b&gt;场景&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="217" />
+        <source>Activate</source>
+        <translation>激活</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="276" />
+        <source>running</source>
+        <translation>运行中</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="276" />
+        <source>stopped</source>
+        <translation>已停止</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="277" />
+        <source>autostart</source>
+        <translation>自启动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="277" />
+        <source>manual</source>
+        <translation>手动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="291" />
+        <source>Autostart: %1</source>
+        <translation>自启动：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="291" />
+        <source>enabled</source>
+        <translation>已启用</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="291" />
+        <source>disabled</source>
+        <translation>已禁用</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="293" />
+        <source>Command: %1</source>
+        <translation>命令：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="299" />
+        <source>Args: %1</source>
+        <translation>参数：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="305" />
+        <source>Env: %1</source>
+        <translation>环境变量：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="314" />
+        <source>Add LLM Provider</source>
+        <translation>添加 LLM 提供商</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="323" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="399" />
+        <source>Name:</source>
+        <translation>名称：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="324" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="400" />
+        <source>Base URL:</source>
+        <translation>地址：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="325" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="401" />
+        <source>API Key:</source>
+        <translation>密钥：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="326" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="402" />
+        <source>Extra body (JSON):</source>
+        <translation>附加请求体 (JSON)：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="354" />
+        <source>LLM provider '%1' already exists.</source>
+        <translation>LLM 提供者 '%1' 已存在。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="366" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="438" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="473" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="611" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="660" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="813" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="902" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="933" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="958" />
+        <source>Failed to save config.</source>
+        <translation>保存配置失败。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="388" />
+        <source>Edit LLM Provider</source>
+        <translation>编辑 LLM 提供商</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="396" />
+        <source>Leave empty to keep current key</source>
+        <translation>留空保持当前密钥不变</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="454" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="632" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="922" />
+        <source>Confirm</source>
+        <translation>确认</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="455" />
+        <source>Are you sure you want to remove LLM provider '%1'?</source>
+        <translation>确定要移除 LLM 提供商"%1"吗？</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="482" />
+        <source>Scenes Updated</source>
+        <translation>场景已更新</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="483" />
+        <source>Removed provider '%1' and cleared it from %2 scene(s).</source>
+        <translation>已移除提供商"%1"，并从 %2 个场景中清除了它的引用。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="498" />
+        <source>Provider '%1' not found.</source>
+        <translation>未找到提供商"%1"。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="504" />
+        <source>Provider base_url is empty.</source>
+        <translation>提供商 base_url 为空。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="512" />
+        <source>Testing...</source>
+        <translation>测试中...</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="540" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="547" />
+        <source>Test Failed</source>
+        <translation>测试失败</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="541" />
+        <source>Connection to '%1' failed:
+%2</source>
+        <translation>连接"%1"失败：
+%2</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="548" />
+        <source>Invalid response from '%1'.</source>
+        <translation>"%1"返回了无效的响应。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="565" />
+        <source>Connected to '%1'.
+Found %2 model(s).</source>
+        <translation>已连接"%1"。
+找到 %2 个模型。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="569" />
+        <source>Test Succeeded</source>
+        <translation>测试成功</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="600" />
+        <source>Adapter '%1' not found in configuration.</source>
+        <translation>配置中未找到适配器"%1"。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="633" />
+        <source>Are you sure you want to remove LLM adapter '%1'?</source>
         <translation>确定要移除 LLM 适配器“%1”吗？</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="704" />
+        <source>LLM Adapter Started</source>
+        <translation>LLM 适配器已启动</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="705" />
+        <source>Adapter '%1' started.</source>
+        <translation>适配器"%1"已启动。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="746" />
+        <source>Add Scene</source>
+        <translation>添加场景</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="767" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="857" />
+        <source>Include raw transcript in candidate options</source>
+        <translation>在候选词选项中包含原始语音文本</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="772" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="863" />
+        <source>ID:</source>
+        <translation>ID：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="773" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="864" />
+        <source>Label:</source>
+        <translation>标签：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="774" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="865" />
+        <source>Prompt:</source>
+        <translation>提示词：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="775" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="866" />
+        <source>Provider:</source>
+        <translation>提供者：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="776" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="867" />
+        <source>Model:</source>
+        <translation>模型：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="777" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="868" />
+        <source>Context Lines:</source>
+        <translation>上下文行数：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="778" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="869" />
+        <source>Candidate Count:</source>
+        <translation>候选数量：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="779" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="870" />
+        <source>Timeout (ms):</source>
+        <translation>超时（毫秒）：</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="834" />
+        <source>Edit Scene</source>
+        <translation>编辑场景</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="922" />
+        <source>Are you sure you want to remove scene '%1'?</source>
+        <translation>确定要移除场景"%1"吗？</translation>
     </message>
 </context>
 <context>
     <name>vinput::gui::ResourcePage</name>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="94" />
         <source>&lt;b&gt;Installed Models&lt;/b&gt;</source>
         <translation>&lt;b&gt;已安装模型&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="96" />
         <source>Filter installed models...</source>
         <translation>筛选已安装模型...</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="124" />
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="124" />
         <source>Hotwords</source>
         <translation>热词</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="124" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="180" />
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="106" />
         <source>Use</source>
         <translation>使用</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="107" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="159" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="184" />
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="108" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="142" />
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="116" />
         <source>&lt;b&gt;Available Models&lt;/b&gt;</source>
         <translation>&lt;b&gt;可用模型&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="118" />
         <source>Filter available models...</source>
         <translation>筛选可用模型...</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="180" />
         <source>Title</source>
         <translation>标题</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="180" />
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="127" />
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Available ASR Providers&lt;/b&gt;</source>
-        <translation>&lt;b&gt;可用 ASR 提供商&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Filter available ASR providers...</source>
-        <translation>筛选可用 ASR 提供商...</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Install</source>
-        <translation>安装</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Available LLM Adapters&lt;/b&gt;</source>
-        <translation>&lt;b&gt;可用 LLM 适配器&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Filter available LLM adapters...</source>
-        <translation>筛选可用 LLM 适配器...</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="133" />
         <source>Models</source>
         <translation>模型</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="147" />
+        <source>&lt;b&gt;Available ASR Providers&lt;/b&gt;</source>
+        <translation>&lt;b&gt;可用 ASR 提供商&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="150" />
+        <source>Filter available ASR providers...</source>
+        <translation>筛选可用 ASR 提供商...</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="158" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="183" />
+        <source>Install</source>
+        <translation>安装</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="169" />
         <source>ASR Providers</source>
         <translation>ASR 提供商</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="173" />
+        <source>&lt;b&gt;Available LLM Adapters&lt;/b&gt;</source>
+        <translation>&lt;b&gt;可用 LLM 适配器&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="175" />
+        <source>Filter available LLM adapters...</source>
+        <translation>筛选可用 LLM 适配器...</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="191" />
         <source>LLM Adapters</source>
         <translation>LLM 适配器</translation>
     </message>
     <message>
-        <source>yes</source>
-        <translation>是</translation>
-    </message>
-    <message>
-        <source>no</source>
-        <translation>否</translation>
-    </message>
-    <message>
-        <source>installed</source>
-        <translation>已安装</translation>
-    </message>
-    <message>
-        <source>active</source>
-        <translation>激活</translation>
-    </message>
-    <message>
-        <source>broken</source>
-        <translation>损坏</translation>
-    </message>
-    <message>
-        <source>available</source>
-        <translation>可下载</translation>
-    </message>
-    <message>
-        <source>stream</source>
-        <translation>流式</translation>
-    </message>
-    <message>
-        <source>non-stream</source>
-        <translation>非流式</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <source>Selected model &apos;%1&apos; saved as the preferred local ASR model. Backend reload is in progress.</source>
-        <translation>已将所选模型&quot;%1&quot;保存为首选本地 ASR 模型。后端正在重新加载。</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>确认</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to remove model &apos;%1&apos;?</source>
-        <translation>确定要移除模型&quot;%1&quot;吗？</translation>
-    </message>
-    <message>
-        <source>Fetching remote registry...</source>
-        <translation>正在获取远程注册表...</translation>
-    </message>
-    <message>
-        <source>Models fetch error: %1</source>
-        <translation>获取模型出错：%1</translation>
-    </message>
-    <message>
-        <source>Providers fetch error: %1</source>
-        <translation>获取提供者出错：%1</translation>
-    </message>
-    <message>
-        <source>Adapters fetch error: %1</source>
-        <translation>获取适配器出错：%1</translation>
-    </message>
-    <message>
-        <source>Registry fetch completed.</source>
-        <translation>注册表获取完成。</translation>
-    </message>
-    <message>
-        <source>Registry warning: %1</source>
-        <translation>注册表警告：%1</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="280" />
         <source>I18n cache reload error: %1</source>
         <translation>i18n 缓存重载错误：%1</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="285" />
+        <source>Registry fetch completed.</source>
+        <translation>注册表获取完成。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="345" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="403" />
+        <source>yes</source>
+        <translation>是</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="345" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="403" />
+        <source>no</source>
+        <translation>否</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="349" />
+        <source>active</source>
+        <translation>激活</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="351" />
+        <source>broken</source>
+        <translation>损坏</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="353" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="407" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="446" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="477" />
+        <source>installed</source>
+        <translation>已安装</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="407" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="446" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="477" />
+        <source>available</source>
+        <translation>可下载</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="443" />
+        <source>stream</source>
+        <translation>流式</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="443" />
+        <source>non-stream</source>
+        <translation>非流式</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="502" />
+        <source>Fetching remote registry...</source>
+        <translation>正在获取远程注册表...</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="548" />
+        <source>Models fetch error: %1</source>
+        <translation>获取模型出错：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="552" />
+        <source>Providers fetch error: %1</source>
+        <translation>获取提供者出错：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="557" />
+        <source>Adapters fetch error: %1</source>
+        <translation>获取适配器出错：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="562" />
+        <source>Registry warning: %1</source>
+        <translation>注册表警告：%1</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="613" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="617" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="661" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="669" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="679" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="944" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="961" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="1021" />
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="617" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="669" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="961" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="1021" />
         <source>Failed to save config.</source>
         <translation>保存配置失败。</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="624" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="970" />
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="625" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="680" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="971" />
         <source>Config saved, but failed to reload ASR backend: %1</source>
         <translation>配置已保存，但重新加载 ASR 后端失败：%1</translation>
     </message>
     <message>
-        <source>Are you sure you want to remove ASR provider &apos;%1&apos;?</source>
-        <translation>确定要移除 ASR 提供商“%1”吗？</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="629" />
+        <source>Selected model '%1' saved as the preferred local ASR model. Backend reload is in progress.</source>
+        <translation>已将所选模型"%1"保存为首选本地 ASR 模型。后端正在重新加载。</translation>
     </message>
     <message>
-        <source>Are you sure you want to remove LLM adapter &apos;%1&apos;?</source>
-        <translation>确定要移除 LLM 适配器“%1”吗？</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="654" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="931" />
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="994" />
+        <source>Confirm</source>
+        <translation>确认</translation>
     </message>
     <message>
-        <source>Removed ASR provider %1.</source>
-        <translation>已移除 ASR 提供商 %1。</translation>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="654" />
+        <source>Are you sure you want to remove model '%1'?</source>
+        <translation>确定要移除模型"%1"吗？</translation>
     </message>
     <message>
-        <source>Removed LLM adapter %1.</source>
-        <translation>已移除 LLM 适配器 %1。</translation>
-    </message>
-    <message>
-        <source>The local ASR provider cannot be removed.</source>
-        <translation>本地 ASR 提供商不能被移除。</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="673" />
         <source>Removed %1.</source>
         <translation>已移除 %1。</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="690" />
         <source>Downloading... %1% at %2</source>
         <translation>正在下载... %1% 速度 %2</translation>
     </message>
     <message>
-        <source>Preparing download...</source>
-        <translation>正在准备下载...</translation>
-    </message>
-    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="697" />
         <source>Download Error</source>
         <translation>下载错误</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="742" />
+        <source>Preparing download...</source>
+        <translation>正在准备下载...</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="771" />
         <source>Starting download for %1...</source>
         <translation>开始下载 %1...</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="822" />
         <source>Installing provider %1...</source>
         <translation>正在安装提供者 %1...</translation>
     </message>
     <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="871" />
         <source>Installing adapter %1...</source>
         <translation>正在安装适配器 %1...</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="931" />
+        <source>Are you sure you want to remove ASR provider '%1'?</source>
+        <translation>确定要移除 ASR 提供商“%1”吗？</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="944" />
+        <source>The local ASR provider cannot be removed.</source>
+        <translation>本地 ASR 提供商不能被移除。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="964" />
+        <source>Removed ASR provider %1.</source>
+        <translation>已移除 ASR 提供商 %1。</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="994" />
+        <source>Are you sure you want to remove LLM adapter '%1'?</source>
+        <translation>确定要移除 LLM 适配器“%1”吗？</translation>
+    </message>
+    <message>
+        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="1024" />
+        <source>Removed LLM adapter %1.</source>
+        <translation>已移除 LLM 适配器 %1。</translation>
     </message>
 </context>
 </TS>

--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -55,6 +55,114 @@
         <source>Start with daemon</source>
         <translation>随守护进程启动</translation>
     </message>
+    <message>
+        <source>Configure LLM Adapter</source>
+        <translation>配置 LLM 适配器</translation>
+    </message>
+    <message>
+        <source>Adapter ID:</source>
+        <translation>适配器 ID：</translation>
+    </message>
+    <message>
+        <source>Command / Interpreter:</source>
+        <translation>命令 / 解释器：</translation>
+    </message>
+    <message>
+        <source>Args:</source>
+        <translation>参数：</translation>
+    </message>
+    <message>
+        <source>Env:</source>
+        <translation>环境变量：</translation>
+    </message>
+    <message>
+        <source>One argument per line</source>
+        <translation>每行一个参数</translation>
+    </message>
+    <message>
+        <source>One KEY=VALUE entry per line</source>
+        <translation>每行一个 KEY=VALUE 条目</translation>
+    </message>
+    <message>
+        <source>Command or interpreter</source>
+        <translation>命令或解释器</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>名称：</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>类型：</translation>
+    </message>
+    <message>
+        <source>Model:</source>
+        <translation>模型：</translation>
+    </message>
+    <message>
+        <source>Timeout (ms):</source>
+        <translation>超时（毫秒）：</translation>
+    </message>
+    <message>
+        <source>local</source>
+        <translation>本地</translation>
+    </message>
+    <message>
+        <source>command</source>
+        <translation>命令</translation>
+    </message>
+    <message>
+        <source>Provider name must not be empty.</source>
+        <translation>提供程序名称不能为空。</translation>
+    </message>
+    <message>
+        <source>Command providers require a command.</source>
+        <translation>命令类型的提供程序需要填写命令。</translation>
+    </message>
+    <message>
+        <source>Loading models...</source>
+        <translation>正在加载模型…</translation>
+    </message>
+    <message>
+        <source>No models returned. You can type one manually.</source>
+        <translation>未返回任何模型，可手动输入。</translation>
+    </message>
+    <message>
+        <source>Invalid env entry &apos;%1&apos;. Use KEY=VALUE.</source>
+        <translation>无效的环境变量条目“%1”，请使用 KEY=VALUE 格式。</translation>
+    </message>
+    <message>
+        <source>Base URL must be a valid http:// or https:// URL.</source>
+        <translation>Base URL 必须是有效的 http:// 或 https:// 地址。</translation>
+    </message>
+    <message>
+        <source>Provider returned invalid JSON for /v1/models.</source>
+        <translation>提供程序的 /v1/models 返回了无效的 JSON。</translation>
+    </message>
+    <message>
+        <source>Failed to load models. Type one manually or reselect the provider to retry.</source>
+        <translation>模型加载失败，可手动输入或重新选择提供程序重试。</translation>
+    </message>
+    <message>
+        <source>running</source>
+        <translation>运行中</translation>
+    </message>
+    <message>
+        <source>stopped</source>
+        <translation>已停止</translation>
+    </message>
+    <message>
+        <source>(not set)</source>
+        <translation>（未设置）</translation>
+    </message>
+    <message>
+        <source>Raw</source>
+        <translation>原始</translation>
+    </message>
+    <message>
+        <source>Command</source>
+        <translation>命令</translation>
+    </message>
 </context>
 <context>
     <name>vinput::gui::ControlPage</name>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-29 11:03+0800\n"
+"POT-Creation-Date: 2026-09-05 22:52+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "... Starting ..."
+msgstr "... 正在启动 ..."
 
 msgid "... Recording ..."
 msgstr "... 正在录音 ..."
@@ -27,6 +30,12 @@ msgstr "... 正在识别 ..."
 
 msgid "... Postprocessing ..."
 msgstr "... 正在后处理 ..."
+
+msgid "Voice input daemon is unavailable."
+msgstr "语音输入守护进程不可用。"
+
+msgid "Voice input daemon is not responding."
+msgstr "语音输入守护进程无响应。"
 
 msgid ""
 "Local ASR model configuration is missing. Please configure a model first."
@@ -151,9 +160,6 @@ msgstr "开始录音失败。"
 msgid "Failed to start command recording."
 msgstr "开始命令录音失败。"
 
-msgid "Failed to reload ASR backend."
-msgstr "重新加载 ASR 后端失败。"
-
 msgid "ASR provider failed to start."
 msgstr "ASR 提供商启动失败。"
 
@@ -188,6 +194,17 @@ msgstr "LLM 请求失败。"
 msgid "LLM request returned an HTTP error."
 msgstr "LLM 请求返回了 HTTP 错误。"
 
+msgid "Failed to load prompt file."
+msgstr "加载 prompt 文件失败。"
+
+#, c-format
+msgid "Failed to load prompt file '%s'."
+msgstr "加载 prompt 文件 '%s' 失败。"
+
+#, c-format
+msgid "Failed to load prompt file '%s': %s"
+msgstr "加载 prompt 文件 '%s' 失败：%s"
+
 msgid "Unknown error during processing."
 msgstr "处理过程中发生未知错误。"
 
@@ -197,7 +214,8 @@ msgstr "启动守护进程失败。"
 msgid "Failed to restart the daemon."
 msgstr "重启守护进程失败。"
 
-msgid "Voice input daemon is busy. Please wait for the current request to finish."
+msgid ""
+"Voice input daemon is busy. Please wait for the current request to finish."
 msgstr "语音输入守护进程正忙。请等待当前请求完成。"
 
 msgid "ASR backend is still loading. Please try again in a moment."
@@ -209,29 +227,23 @@ msgstr "ASR 后端重新加载失败。此前的后端可能仍在使用中。"
 msgid "Unknown error."
 msgstr "未知错误。"
 
-msgid "Voice Input"
-msgstr "语音输入"
-
-msgid "Voice input daemon is unavailable."
-msgstr "语音输入守护进程不可用。"
-
-msgid "Voice input daemon is not responding."
-msgstr "语音输入守护进程无响应。"
-
-msgid "Voice input daemon is temporarily unavailable."
-msgstr "语音输入守护进程暂时不可用。"
-
-msgid "... Starting ..."
-msgstr "... 正在启动 ..."
-
 msgid "Daemon access is temporarily throttled."
 msgstr "守护进程访问暂时被限流。"
 
 msgid "Failed to contact vinput-daemon."
 msgstr "无法连接到 vinput-daemon。"
 
-msgid "Failed to query ASR backend state."
-msgstr "查询 ASR 后端状态失败。"
+msgid "Failed to reload ASR backend."
+msgstr "重新加载 ASR 后端失败。"
+
+msgid "Failed to start adapter."
+msgstr "启动适配器失败。"
+
+msgid "Failed to stop adapter."
+msgstr "停止适配器失败。"
+
+msgid "Voice Input"
+msgstr "语音输入"
 
 msgid "Please select text first."
 msgstr "请先选中文本。"
@@ -242,49 +254,105 @@ msgstr "命令模式已禁用（候选数为 0）。"
 msgid "No LLM provider configured for command mode."
 msgstr "未配置命令模式的 LLM 提供者。"
 
-msgid "Scenes /filter"
-msgstr "场景 /过滤"
+msgid "Voice input daemon is temporarily unavailable."
+msgstr "语音输入守护进程暂时不可用。"
 
-msgid "Models /filter"
-msgstr "模型 /过滤"
-
-msgid "Current: "
-msgstr "当前："
-
-msgid "Recording is not active."
-msgstr "当前未在录音。"
+msgid "Command Palette"
+msgstr "命令面板"
 
 #, c-format
-msgid "Switched scene to '%s'."
-msgstr "已切换场景到 '%s'。"
+msgid "Search: %s"
+msgstr "搜索: %s"
 
 #, c-format
-msgid "Switched ASR to '%s'."
-msgstr "已切换 ASR 到 '%s'。"
+msgid "Choose Result (%zu)"
+msgstr "选择结果（%zu项）"
+
+msgid "Original"
+msgstr "原文"
+
+msgid "Voice Command"
+msgstr "语音命令"
+
+msgid "Cmd-Model"
+msgstr "Cmd-Model"
+
+msgid "Switch command model"
+msgstr "切换划词指令模型"
+
+msgid "Cmd-Model *"
+msgstr "Cmd-Model *"
+
+msgid "Failed to set command model."
+msgstr "设置划词指令模型失败。"
 
 #, c-format
-msgid "Switching ASR to '%s'."
-msgstr "正在切换 ASR 到 '%s'。"
+msgid "Command model set to '%s / %s'."
+msgstr "划词指令模型已设置为 '%s / %s'。"
+
+msgid "ASR"
+msgstr "ASR"
+
+msgid "Switch ASR provider or model"
+msgstr "切换 ASR 提供商或模型"
+
+msgid "ASR *"
+msgstr "ASR *"
+
+#, c-format
+msgid ""
+"ASR provider '%s' is a local provider, which is not supported in this Lite "
+"build."
+msgstr "ASR 提供商 '%s' 为本地提供商，当前轻量版不支持。"
+
+msgid "Failed to save ASR config."
+msgstr "保存语音识别配置失败。"
 
 #, c-format
 msgid "ASR switch requested for '%s'."
 msgstr "已请求切换 ASR 到 '%s'。"
 
-#, c-format
-msgid "Saved ASR selection '%s', but the runtime is still using the previous backend."
-msgstr "已保存 ASR 选择 '%s'，但运行时仍在使用之前的后端。"
+msgid "Scene"
+msgstr "Scene"
+
+msgid "Switch dictation scene"
+msgstr "切换听写场景"
+
+msgid "Scene *"
+msgstr "Scene *"
+
+msgid "Failed to save scene config."
+msgstr "保存场景配置失败。"
 
 #, c-format
-msgid "Saved ASR selection '%s', but no usable ASR backend is active."
-msgstr "已保存 ASR 选择 '%s'，但当前没有可用的 ASR 后端处于活动状态。"
+msgid "Scene switched to '%s'."
+msgstr "场景已切换为 '%s'。"
+
+msgid "Proc"
+msgstr "Proc"
+
+msgid "Manage adapter processes"
+msgstr "管理适配器进程"
+
+msgid "Proc (running · autostart)"
+msgstr "Proc (运行中 · 自启)"
+
+msgid "Proc (running)"
+msgstr "Proc (运行中)"
+
+msgid "Proc (stopped · autostart)"
+msgstr "Proc (已停止 · 自启)"
+
+msgid "Proc (stopped)"
+msgstr "Proc (已停止)"
 
 #, c-format
-msgid "Config saved, but ASR backend reload was skipped: %s"
-msgstr "配置已保存，但 ASR 后端重载已跳过：%s"
+msgid "Adapter '%s' stopped."
+msgstr "Adapter '%s' 已停止。"
 
 #, c-format
-msgid "Config saved, but failed to reload ASR backend: %s"
-msgstr "配置已保存，但重新加载 ASR 后端失败：%s"
+msgid "Adapter '%s' started."
+msgstr "Adapter '%s' 已启动。"
 
 #, c-format
 msgid "Config saved, but failed to confirm ASR runtime state: %s"
@@ -306,27 +374,12 @@ msgid "Config saved. ASR runtime state is updating."
 msgstr "配置已保存。ASR 运行时状态正在更新。"
 
 #, c-format
-msgid "Choose Result (%zu)"
-msgstr "选择结果（%zu项）"
-
-msgid "Original"
-msgstr "原文"
-
-msgid "Voice Command"
-msgstr "语音命令"
+msgid "Config saved, but ASR backend reload was skipped: %s"
+msgstr "配置已保存，但 ASR 后端重载已跳过：%s"
 
 #, c-format
-msgid " (%d/%d)"
-msgstr "（%d/%d页）"
-
-msgid " (Current)"
-msgstr "（当前）"
-
-msgid "Failed to save active scene."
-msgstr "保存当前活跃场景失败。"
-
-msgid "Failed to save ASR config."
-msgstr "保存语音识别配置失败。"
+msgid "Config saved, but failed to reload ASR backend: %s"
+msgstr "配置已保存，但重新加载 ASR 后端失败：%s"
 
 msgid "ID"
 msgstr "ID"
@@ -361,6 +414,11 @@ msgstr "查看文档"
 #, c-format
 msgid "ASR provider '%s' not found."
 msgstr "未找到 ASR 提供商 '%s'。"
+
+msgid ""
+"The local ASR provider cannot be removed. It is required for model "
+"management."
+msgstr "内置的本地语音识别不可移除。它是模型管理所必需的。"
 
 #, c-format
 msgid "ASR provider '%s' removed."
@@ -427,11 +485,11 @@ msgstr ""
 msgid "LANGUAGE"
 msgstr "语言"
 
-msgid "SIZE"
-msgstr "大小"
-
 msgid "HOTWORDS"
 msgstr "热词"
+
+msgid "SIZE"
+msgstr "大小"
 
 msgid "Installed"
 msgstr "已安装"
@@ -538,11 +596,40 @@ msgstr "已创建模型目录：%s"
 msgid "Everything already initialized"
 msgstr "所有文件已就绪，无需初始化"
 
+#, c-format
+msgid "Adapter '%s' not found."
+msgstr "未找到适配器 '%s'。"
+
+#, c-format
+msgid "Adapter '%s' enabled to autostart with daemon."
+msgstr "已启用适配器 '%s' 随 daemon 自启动。"
+
+#, c-format
+msgid "Adapter '%s' disabled from autostart with daemon."
+msgstr "已禁用适配器 '%s' 随 daemon 自启动。"
+
+msgid ""
+"--extra-body must be a JSON object (e.g. '{\"enable_thinking\": false}')."
+msgstr "--extra-body 必须是 JSON 对象（例如 '{\"enable_thinking\": false}'）。"
+
+#, c-format
+msgid "Invalid --extra-body JSON: %s"
+msgstr "--extra-body JSON 无效：%s"
+
 msgid "API_KEY"
 msgstr "API 密钥"
 
 msgid "BASE_URL"
 msgstr "服务地址"
+
+msgid "AUTOSTART"
+msgstr "自启动"
+
+msgid "disabled"
+msgstr "已禁用"
+
+msgid "enabled"
+msgstr "已启用"
 
 msgid ""
 "No LLM adapter registry base URLs configured. Edit config.json and set "
@@ -568,12 +655,38 @@ msgid "Adapter '%s' added."
 msgstr "适配器 '%s' 已添加。"
 
 #, c-format
-msgid "Adapter '%s' started."
-msgstr "Adapter '%s' 已启动。"
+msgid "Adapter '%s' restarted."
+msgstr "Adapter '%s' 已重启。"
 
-#, c-format
-msgid "Adapter '%s' stopped."
-msgstr "Adapter '%s' 已停止。"
+msgid "PID"
+msgstr "PID"
+
+msgid "COMMAND"
+msgstr "命令"
+
+msgid "running"
+msgstr "运行中"
+
+msgid "stopped"
+msgstr "已停止"
+
+msgid "PROPERTY"
+msgstr "属性"
+
+msgid "Title"
+msgstr "名称"
+
+msgid "Status"
+msgstr "状态"
+
+msgid "Autostart"
+msgstr "自启动"
+
+msgid "Command"
+msgstr "命令"
+
+msgid "Args"
+msgstr "参数"
 
 #, c-format
 msgid "LLM provider '%s' not found."
@@ -586,6 +699,28 @@ msgstr "LLM 提供商 '%s' 已移除。"
 #, c-format
 msgid "LLM provider '%s' updated."
 msgstr "LLM 提供商 '%s' 已更新。"
+
+msgid "Provider base_url is empty."
+msgstr "提供商 base_url 为空。"
+
+msgid "Failed to initialize libcurl."
+msgstr "初始化 libcurl 失败。"
+
+#, c-format
+msgid "Connection failed: %s"
+msgstr "连接失败：%s"
+
+#, c-format
+msgid "HTTP %ld: %s"
+msgstr "HTTP %ld：%s"
+
+#, c-format
+msgid "Invalid JSON response: %s"
+msgstr "无效的 JSON 响应：%s"
+
+#, c-format
+msgid "Connected to '%s'. Found %d model(s)."
+msgstr "已连接'%s'。找到 %d 个模型。"
 
 msgid "Manage hotword file"
 msgstr "管理热词文件"
@@ -713,11 +848,24 @@ msgstr "服务地址"
 msgid "API key"
 msgstr "API 密钥"
 
+msgid ""
+"Extra JSON object merged into each request body (e.g. '{\"enable_thinking\": "
+"false}')"
+msgstr ""
+"合并进每次请求体的附加 JSON 对象（例如 '{\"enable_thinking\": false}'）"
+
 msgid "Remove an LLM provider"
 msgstr "移除 LLM 提供商"
 
 msgid "Edit an LLM provider"
 msgstr "编辑 LLM 提供商"
+
+#, c++-format
+msgid "Extra JSON object merged into each request body; pass '{}' to clear"
+msgstr "合并进每次请求体的附加 JSON 对象；传 '{}' 清空"
+
+msgid "Test LLM provider connectivity"
+msgstr "测试 LLM 提供商连通性"
 
 msgid "Manage LLM adapters"
 msgstr "管理 LLM 适配器"
@@ -728,17 +876,32 @@ msgstr "列出适配器"
 msgid "List remote adapters"
 msgstr "列出远程适配器"
 
-msgid "Add an adapter"
-msgstr "添加适配器"
+msgid "List adapter processes and runtime status"
+msgstr "列出适配器进程与运行状态"
+
+msgid "Show adapter status"
+msgstr "显示适配器状态"
 
 msgid "Adapter short ID"
 msgstr "适配器短 ID"
+
+msgid "Add an adapter"
+msgstr "添加适配器"
 
 msgid "Start an adapter"
 msgstr "启动适配器"
 
 msgid "Stop an adapter"
 msgstr "停止适配器"
+
+msgid "Restart an adapter"
+msgstr "重启适配器"
+
+msgid "Enable adapter autostart with daemon"
+msgstr "启用适配器随 daemon 自启动"
+
+msgid "Disable adapter autostart with daemon"
+msgstr "禁用适配器随 daemon 自启动"
 
 msgid "Manage recognition scenes"
 msgstr "管理识别场景"
@@ -764,14 +927,17 @@ msgstr "LLM 提供商 ID"
 msgid "LLM model id"
 msgstr "LLM 模型 ID"
 
-msgid "Candidate count"
-msgstr "候选数量"
+msgid "Maximum number of LLM candidates (0 to disable LLM)"
+msgstr "LLM 候选的最大返回数量（0 表示不使用 LLM）"
 
 msgid "Request timeout in milliseconds"
 msgstr "请求超时时间（毫秒）"
 
 msgid "Number of previous lines sent as LLM context"
 msgstr "发送给 LLM 作为上下文的前文行数"
+
+msgid "Include raw ASR transcript in candidate options (true/false)"
+msgstr "在候选词选项中包含原始语音文本 (true/false)"
 
 msgid "Set active scene"
 msgstr "设置当前场景"
@@ -788,8 +954,11 @@ msgstr "标签"
 msgid "PROVIDER"
 msgstr "提供者"
 
-msgid "CANDIDATES"
-msgstr "候选数"
+msgid "COUNT"
+msgstr "数量"
+
+msgid "SHOW_RAW"
+msgstr "包含原句"
 
 #, c-format
 msgid "Scene '%s' added."
@@ -821,10 +990,6 @@ msgstr "守护进程状态：%s"
 msgid "Daemon started."
 msgstr "守护进程已启动。"
 
-#, c-format
-msgid "systemctl start failed (exit code: %d)"
-msgstr "systemctl start 失败（退出码：%d）"
-
 msgid "Daemon stopped."
 msgstr "守护进程已停止。"
 
@@ -834,10 +999,6 @@ msgstr "systemctl stop 失败（退出码：%d）"
 
 msgid "Daemon restarted."
 msgstr "守护进程已重启。"
-
-#, c-format
-msgid "systemctl restart failed (exit code: %d)"
-msgstr "systemctl restart 失败（退出码：%d）"
 
 msgid "Recording started."
 msgstr "录音已开始。"
@@ -904,33 +1065,6 @@ msgstr "显示此帮助信息并退出"
 msgid "Display program version information and exit"
 msgstr "显示程序版本信息并退出"
 
-msgid "Usage"
-msgstr "用法"
-
-msgid "OPTIONS"
-msgstr "选项"
-
-msgid "SUBCOMMAND"
-msgstr "子命令"
-
-msgid "SUBCOMMANDS"
-msgstr "子命令"
-
-msgid "Positionals"
-msgstr "位置参数"
-
-msgid "REQUIRED"
-msgstr "必填"
-
-msgid "Env"
-msgstr "环境变量"
-
-msgid "Needs"
-msgstr "依赖"
-
-msgid "Excludes"
-msgstr "互斥"
-
 msgid "Output in JSON format"
 msgstr "以 JSON 格式输出"
 
@@ -957,16 +1091,18 @@ msgid ""
 "text. If there is no active selection, vinput falls back to the current "
 "primary-selection clipboard text. Default is Right Control."
 msgstr ""
-"按住该键录制语音指令，将对当前选中的文本进行处理。如果没有选中文本，"
-"vinput 将使用当前主选区剪贴板内容。默认是右 Ctrl。"
+"按住该键录制语音指令，将对当前选中的文本进行处理。如果没有选中文本，vinput 将"
+"使用当前主选区剪贴板内容。默认是右 Ctrl。"
 
-msgid "Postprocess Menu Keys"
-msgstr "后处理选单键"
+msgid "Command Palette Keys"
+msgstr "命令面板快捷键"
 
 msgid ""
-"Configure one or more keys to open the unified command palette (/model, "
-"/asr, /scene, /proc). The default is Right Shift."
-msgstr "配置打开统一命令面板（/model、/asr、/scene、/proc）的一个或多个快捷键。默认是右 Shift。"
+"Configure one or more keys to open the unified command palette (/model, /"
+"asr, /scene, /proc). The default is Right Shift."
+msgstr ""
+"配置打开统一命令面板（/model、/asr、/scene、/proc）的一个或多个快捷键。默认是"
+"右 Shift。"
 
 msgid "Previous Page Keys"
 msgstr "上一页键"
@@ -987,14 +1123,34 @@ msgstr ""
 "用于后处理选单和后处理候选菜单翻到下一页。默认是 Page Down 和小键盘 Page "
 "Down。"
 
+msgid "Trigger Mode"
+msgstr "触发模式"
+
+msgid "Max Streaming Display Width"
+msgstr "流式识别最大显示列宽"
+
+msgid ""
+"Maximum visual column width for live streaming recognition preview. Older "
+"text is folded into 'head...tail'. Set to 0 to disable folding. Default is "
+"60."
+msgstr ""
+"实时流式识别预览的最大视觉显示列宽。较早的内容会被折叠为“句首...句尾”。设为 "
+"0 则禁用折叠。默认值为 60。"
+
 msgid "Open Vinput Settings"
 msgstr "打开 Vinput 设置"
 
+msgid "Both"
+msgstr "均可"
+
+msgid "Hold"
+msgstr "长按"
+
+msgid "Tap"
+msgstr "短按"
+
 msgid "Raw"
 msgstr "原始"
-
-msgid "Command"
-msgstr "命令"
 
 #, c-format
 msgid "Local ASR model configuration is missing for provider '%s'."
@@ -1006,230 +1162,5 @@ msgstr "ASR 已被命令行禁用。"
 msgid "No active ASR provider configured."
 msgstr "未配置活跃的 ASR 提供商。"
 
-msgid "Test LLM provider connectivity"
-msgstr "测试 LLM 提供商连通性"
-
-msgid "Provider base_url is empty."
-msgstr "提供商 base_url 为空。"
-
-msgid "Failed to initialize libcurl."
-msgstr "初始化 libcurl 失败。"
-
-#, c-format
-msgid "Connection failed: %s"
-msgstr "连接失败：%s"
-
-#, c-format
-msgid "HTTP %ld: %s"
-msgstr "HTTP %ld：%s"
-
-#, c-format
-msgid "Invalid JSON response: %s"
-msgstr "无效的 JSON 响应：%s"
-
-#, c-format
-msgid "Connected to '%s'. Found %d model(s)."
-msgstr "已连接'%s'。找到 %d 个模型。"
-
-msgid ""
-"Extra JSON object merged into each request body (e.g. '{\"enable_thinking\": "
-"false}')"
-msgstr "合并进每次请求体的附加 JSON 对象（例如 '{\"enable_thinking\": false}'）"
-
-msgid "Extra JSON object merged into each request body; pass '{}' to clear"
-msgstr "合并进每次请求体的附加 JSON 对象；传 '{}' 清空"
-
-msgid ""
-"--extra-body must be a JSON object (e.g. '{\"enable_thinking\": false}')."
-msgstr "--extra-body 必须是 JSON 对象（例如 '{\"enable_thinking\": false}'）。"
-
-#, c-format
-msgid "Invalid --extra-body JSON: %s"
-msgstr "--extra-body JSON 无效：%s"
-
-msgid "Trigger Mode"
-msgstr "触发模式"
-
-msgid "Tap"
-msgstr "短按"
-
-msgid "Hold"
-msgstr "长按"
-
-msgid "Both"
-msgstr "均可"
-
-msgid "Failed to load prompt file."
-msgstr "加载 prompt 文件失败。"
-
-#, c-format
-msgid "Failed to load prompt file '%s'."
-msgstr "加载 prompt 文件 '%s' 失败。"
-
-#, c-format
-msgid "Failed to load prompt file '%s': %s"
-msgstr "加载 prompt 文件 '%s' 失败：%s"
-
-msgid "Max Streaming Display Width"
-msgstr "流式识别最大显示列宽"
-
-msgid "Maximum visual column width for live streaming recognition preview. Older text is folded into 'head...tail'. Set to 0 to disable folding. Default is 60."
-msgstr "实时流式识别预览的最大视觉显示列宽。较早的内容会被折叠为“句首...句尾”。设为 0 则禁用折叠。默认值为 60。"
-
-msgid "AUTOSTART"
-msgstr "自启动"
-
-#, c-format
-msgid "Adapter '%s' not found."
-msgstr "未找到适配器 '%s'。"
-
-msgid "List adapter processes and runtime status"
-msgstr "列出适配器进程与运行状态"
-
-msgid "Show adapter status"
-msgstr "显示适配器状态"
-
-#, c-format
-msgid "Adapter '%s' enabled to autostart with daemon."
-msgstr "已启用适配器 '%s' 随 daemon 自启动。"
-
-#, c-format
-msgid "Adapter '%s' disabled from autostart with daemon."
-msgstr "已禁用适配器 '%s' 随 daemon 自启动。"
-
-msgid "PID"
-msgstr "PID"
-
-msgid "COMMAND"
-msgstr "命令"
-
-msgid "PROPERTY"
-msgstr "属性"
-
-msgid "Title"
-msgstr "名称"
-
-msgid "Status"
-msgstr "状态"
-
-msgid "Autostart"
-msgstr "自启动"
-
-msgid "Args"
-msgstr "参数"
-
-msgid "disabled"
-msgstr "已禁用"
-
-msgid "enabled"
-msgstr "已启用"
-
-msgid "running"
-msgstr "运行中"
-
-msgid "stopped"
-msgstr "已停止"
-
-msgid "Restart an adapter"
-msgstr "重启适配器"
-
-msgid "Enable adapter autostart with daemon"
-msgstr "启用适配器随 daemon 自启动"
-
-msgid "Disable adapter autostart with daemon"
-msgstr "禁用适配器随 daemon 自启动"
-
-#, c-format
-msgid "Adapter '%s' restarted."
-msgstr "Adapter '%s' 已重启。"
-
-msgid "Maximum number of LLM candidates (0 to disable LLM)"
-msgstr "LLM 候选的最大返回数量（0 表示不使用 LLM）"
-
-msgid "COUNT"
-msgstr "数量"
-
-msgid "Command Palette"
-msgstr "命令面板"
-
-msgid "Cmd-Model"
-msgstr "Cmd-Model"
-
-msgid "Cmd-Model *"
-msgstr "Cmd-Model *"
-
-msgid "ASR"
-msgstr "ASR"
-
-msgid "ASR *"
-msgstr "ASR *"
-
-msgid "Scene"
-msgstr "Scene"
-
-msgid "Scene *"
-msgstr "Scene *"
-
-msgid "Proc"
-msgstr "Proc"
-
-msgid "Proc (running · autostart)"
-msgstr "Proc (运行中 · 自启)"
-
-msgid "Proc (running)"
-msgstr "Proc (运行中)"
-
-msgid "Proc (stopped · autostart)"
-msgstr "Proc (已停止 · 自启)"
-
-msgid "Proc (stopped)"
-msgstr "Proc (已停止)"
-
-#, c-format
-msgid "Search: %s"
-msgstr "搜索: %s"
-
-msgid "Switch command model"
-msgstr "切换划词指令模型"
-
-msgid "Switch ASR provider or model"
-msgstr "切换 ASR 提供商或模型"
-
-msgid "Switch dictation scene"
-msgstr "切换听写场景"
-
-msgid "Manage adapter processes"
-msgstr "管理适配器进程"
-
-msgid "Command Palette Keys"
-msgstr "命令面板快捷键"
-
-#, c-format
-msgid "Command model set to '%s / %s'."
-msgstr "划词指令模型已设置为 '%s / %s'。"
-
-#, c-format
-msgid "Scene switched to '%s'."
-msgstr "场景已切换为 '%s'。"
-
-msgid "Failed to save scene config."
-msgstr "保存场景配置失败。"
-
-msgid "Failed to set command model."
-msgstr "设置划词指令模型失败。"
-
-msgid "Failed to start adapter."
-msgstr "启动适配器失败。"
-
-msgid "Failed to stop adapter."
-msgstr "停止适配器失败。"
-
-#, c-format
-msgid "ASR provider '%s' is a local provider, which is not supported in this Lite build."
-msgstr "ASR 提供商 '%s' 为本地提供商，当前轻量版不支持。"
-
-msgid "Include raw ASR transcript in candidate options (true/false)"
-msgstr "在候选词选项中包含原始语音文本 (true/false)"
-
-msgid "SHOW_RAW"
-msgstr "包含原句"
+msgid "Recording is not active."
+msgstr "当前未在录音。"

--- a/scripts/check-i18n.py
+++ b/scripts/check-i18n.py
@@ -15,7 +15,7 @@ PROJECT_ROOT = SCRIPT_DIR.parent
 PO_FILE = PROJECT_ROOT / "po" / "zh_CN.po"
 TS_FILE = PROJECT_ROOT / "i18n" / "vinput-gui_zh_CN.ts"
 
-SRC_DIRS = ["src/cli", "src/common", "src/addon"]
+SRC_DIRS = ["src/cli", "src/common", "src/addon", "src/daemon"]
 
 # Colors (disabled when not a terminal)
 if sys.stdout.isatty():
@@ -25,14 +25,31 @@ else:
 
 
 def extract_po_msgids(path: str) -> set[str]:
-    """Extract msgid strings from a .po/.pot file (skip header)."""
+    """Extract msgid strings from a .po/.pot file (skip header and obsolete #~)."""
     ids = set()
     with open(path, encoding="utf-8") as f:
         text = f.read()
-    for m in re.finditer(r'^msgid "(.*)"$', text, re.MULTILINE):
-        val = m.group(1)
-        if val:
-            ids.add(val)
+    for entry in re.split(r"\n\n+", text):
+        lines = [line.strip() for line in entry.splitlines() if line.strip()]
+        if not lines or lines[0].startswith("#~"):
+            continue
+        msgid_parts = []
+        in_msgid = False
+        for line in lines:
+            if line.startswith("msgid "):
+                in_msgid = True
+                m = re.match(r'^msgid\s+"(.*)"$', line)
+                if m:
+                    msgid_parts.append(m.group(1).encode().decode("unicode_escape", "ignore"))
+            elif in_msgid and line.startswith('"') and line.endswith('"'):
+                m = re.match(r'^"(.*)"$', line)
+                if m:
+                    msgid_parts.append(m.group(1).encode().decode("unicode_escape", "ignore"))
+            elif line.startswith("msgstr "):
+                in_msgid = False
+        full_id = "".join(msgid_parts)
+        if full_id:
+            ids.add(full_id)
     return ids
 
 
@@ -52,14 +69,39 @@ def extract_po_untranslated(path: str) -> set[str]:
     ids = set()
     with open(path, encoding="utf-8") as f:
         text = f.read()
-    # Split into entries by double newline
     for entry in re.split(r"\n\n+", text):
-        if entry.startswith("#~"):
+        lines = [line.strip() for line in entry.splitlines() if line.strip()]
+        if not lines or lines[0].startswith("#~"):
             continue
-        mid = re.search(r'^msgid "(.*)"$', entry, re.MULTILINE)
-        mstr = re.search(r'^msgstr "(.*)"$', entry, re.MULTILINE)
-        if mid and mid.group(1) and mstr and not mstr.group(1):
-            ids.add(mid.group(1))
+        msgid_parts = []
+        msgstr_parts = []
+        in_msgid = False
+        in_msgstr = False
+        for line in lines:
+            if line.startswith("msgid "):
+                in_msgid = True
+                in_msgstr = False
+                m = re.match(r'^msgid\s+"(.*)"$', line)
+                if m:
+                    msgid_parts.append(m.group(1).encode().decode("unicode_escape", "ignore"))
+            elif in_msgid and line.startswith('"') and line.endswith('"'):
+                m = re.match(r'^"(.*)"$', line)
+                if m:
+                    msgid_parts.append(m.group(1).encode().decode("unicode_escape", "ignore"))
+            elif line.startswith("msgstr "):
+                in_msgid = False
+                in_msgstr = True
+                m = re.match(r'^msgstr\s+"(.*)"$', line)
+                if m:
+                    msgstr_parts.append(m.group(1).encode().decode("unicode_escape", "ignore"))
+            elif in_msgstr and line.startswith('"') and line.endswith('"'):
+                m = re.match(r'^"(.*)"$', line)
+                if m:
+                    msgstr_parts.append(m.group(1).encode().decode("unicode_escape", "ignore"))
+        full_id = "".join(msgid_parts)
+        full_str = "".join(msgstr_parts)
+        if full_id and not full_str.strip():
+            ids.add(full_id)
     return ids
 
 
@@ -156,17 +198,16 @@ def main() -> int:
         )
 
         pot_ids = extract_po_msgids(tmp_pot)
-        po_ids = extract_po_msgids(str(PO_FILE)) - extract_po_obsolete_msgids(
-            str(PO_FILE)
-        )
+        po_ids = extract_po_msgids(str(PO_FILE))
 
         # Missing: in source but not in .po
         for mid in sorted(pot_ids - po_ids):
             print(f"{RED}MISSING:{RESET} {mid}")
             po_missing += 1
 
-        # Obsolete: marked #~ in .po
-        for mid in sorted(extract_po_obsolete_msgids(str(PO_FILE))):
+        # Obsolete: in .po but no longer in source, or marked #~
+        obsolete_ids = (po_ids - pot_ids) | extract_po_obsolete_msgids(str(PO_FILE))
+        for mid in sorted(obsolete_ids):
             print(f"{YELLOW}OBSOLETE:{RESET} {mid}")
             po_obsolete += 1
 

--- a/scripts/check-i18n.py
+++ b/scripts/check-i18n.py
@@ -109,7 +109,7 @@ def ts_untranslated(path: Path) -> set[str]:
 
 
 def find_lupdate() -> str | None:
-    for cmd in ("lupdate-qt6", "lupdate"):
+    for cmd in ("lupdate-qt6", "lupdate6", "lupdate"):
         if subprocess.run(["which", cmd], capture_output=True).returncode == 0:
             return cmd
     return None

--- a/src/gui/app/main.cpp
+++ b/src/gui/app/main.cpp
@@ -4,6 +4,8 @@
 #include <QLocale>
 #include <QStandardPaths>
 #include <QTranslator>
+#include <QtCore/qlibraryinfo.h>
+#include <QtCore/qstringliteral.h>
 
 #include "mainwindow.h"
 
@@ -66,7 +68,7 @@ int main(int argc, char* argv[]) {
 
   QTranslator translator;
   if (TryLoadTranslation(translator, "vinput-gui")) {
-    app.installTranslator(&translator);
+    QCoreApplication::installTranslator(&translator);
   }
 
   // Qt's own translations (qtbase_*) cover standard dialog buttons such as
@@ -74,7 +76,7 @@ int main(int argc, char* argv[]) {
   QTranslator qtTranslator;
   if (qtTranslator.load(QLocale::system(), QStringLiteral("qtbase"), QStringLiteral("_"),
                         QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
-    app.installTranslator(&qtTranslator);
+    QCoreApplication::installTranslator(&qtTranslator);
   }
 
   MainWindow window;

--- a/src/gui/app/main.cpp
+++ b/src/gui/app/main.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QDir>
+#include <QLibraryInfo>
 #include <QLocale>
 #include <QStandardPaths>
 #include <QTranslator>
@@ -66,6 +67,14 @@ int main(int argc, char* argv[]) {
   QTranslator translator;
   if (TryLoadTranslation(translator, "vinput-gui")) {
     app.installTranslator(&translator);
+  }
+
+  // Qt's own translations (qtbase_*) cover standard dialog buttons such as
+  // OK/Cancel in QDialogButtonBox.
+  QTranslator qtTranslator;
+  if (qtTranslator.load(QLocale::system(), QStringLiteral("qtbase"), QStringLiteral("_"),
+                        QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
+    app.installTranslator(&qtTranslator);
   }
 
   MainWindow window;

--- a/src/gui/dialogs/adapter_dialog.cpp
+++ b/src/gui/dialogs/adapter_dialog.cpp
@@ -9,7 +9,10 @@
 #include <QMessageBox>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <QtCore/qcoreapplication.h>
 #include <QtWidgets/qcheckbox.h>
+#include <QtWidgets/qlabel.h>
+#include <QtWidgets/qmessagebox.h>
 
 #include "utils/gui_helpers.h"
 

--- a/src/gui/dialogs/adapter_dialog.cpp
+++ b/src/gui/dialogs/adapter_dialog.cpp
@@ -17,6 +17,10 @@ namespace vinput::gui {
 
 namespace {
 
+struct AdapterDialog {
+  Q_DECLARE_TR_FUNCTIONS(AdapterDialog)
+};
+
 QString JoinArgLines(const std::vector<std::string>& args) {
   std::string joined;
   for (std::size_t i = 0; i < args.size(); ++i) {
@@ -47,7 +51,7 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
 
   while (true) {
     QDialog dialog(parent);
-    dialog.setWindowTitle(GuiTranslate("Configure LLM Adapter"));
+    dialog.setWindowTitle(AdapterDialog::tr("Configure LLM Adapter"));
 
     auto* layout = new QVBoxLayout(&dialog);
 
@@ -58,20 +62,20 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
 
     textArgs->setMaximumHeight(90);
     textEnv->setMaximumHeight(120);
-    textArgs->setPlaceholderText(GuiTranslate("One argument per line"));
-    textEnv->setPlaceholderText(GuiTranslate("One KEY=VALUE entry per line"));
-    editCommand->setPlaceholderText(GuiTranslate("Command or interpreter"));
+    textArgs->setPlaceholderText(AdapterDialog::tr("One argument per line"));
+    textEnv->setPlaceholderText(AdapterDialog::tr("One KEY=VALUE entry per line"));
+    editCommand->setPlaceholderText(AdapterDialog::tr("Command or interpreter"));
 
     editCommand->setText(QString::fromStdString(initial.command));
     textArgs->setPlainText(JoinArgLines(initial.args));
     textEnv->setPlainText(JoinEnvLines(initial.env));
 
-    form->addRow(GuiTranslate("Adapter ID:"), new QLabel(QString::fromStdString(initial.id)));
-    form->addRow(GuiTranslate("Command / Interpreter:"), editCommand);
-    form->addRow(GuiTranslate("Args:"), textArgs);
-    form->addRow(GuiTranslate("Env:"), textEnv);
+    form->addRow(AdapterDialog::tr("Adapter ID:"), new QLabel(QString::fromStdString(initial.id)));
+    form->addRow(AdapterDialog::tr("Command / Interpreter:"), editCommand);
+    form->addRow(AdapterDialog::tr("Args:"), textArgs);
+    form->addRow(AdapterDialog::tr("Env:"), textEnv);
 
-    auto* chkAutoStart = new QCheckBox(GuiTranslate("Start with daemon"));
+    auto* chkAutoStart = new QCheckBox(AdapterDialog::tr("Start with daemon"));
     chkAutoStart->setChecked(initial.autoStart);
     form->addRow(QString(), chkAutoStart);
 
@@ -95,7 +99,7 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
     }
     QString env_error;
     if (!ParseCommandEnv(textEnv->toPlainText(), &out_data->env, &env_error)) {
-      QMessageBox::warning(parent, GuiTranslate("Error"), env_error);
+      QMessageBox::warning(parent, AdapterDialog::tr("Error"), env_error);
       continue;
     }
 

--- a/src/gui/dialogs/asr_provider_dialog.cpp
+++ b/src/gui/dialogs/asr_provider_dialog.cpp
@@ -27,6 +27,10 @@ namespace vinput::gui {
 
 namespace {
 
+struct AsrProviderDialog {
+  Q_DECLARE_TR_FUNCTIONS(AsrProviderDialog)
+};
+
 constexpr char kLocalType[] = "local";
 constexpr char kCommandType[] = "command";
 
@@ -100,13 +104,13 @@ bool ShowAsrProviderDialog(QWidget* parent, const QString& title, const AsrProvi
     auto* spinTimeout = new QSpinBox();
 
 #if VINPUT_ENABLE_LOCAL_ASR
-    comboType->addItem(GuiTranslate("local"), QString(kLocalType));
+    comboType->addItem(AsrProviderDialog::tr("local"), QString(kLocalType));
 #endif
-    comboType->addItem(GuiTranslate("command"), QString(kCommandType));
+    comboType->addItem(AsrProviderDialog::tr("command"), QString(kCommandType));
     textArgs->setMaximumHeight(90);
     textEnv->setMaximumHeight(90);
-    textArgs->setPlaceholderText(GuiTranslate("One argument per line"));
-    textEnv->setPlaceholderText(GuiTranslate("One KEY=VALUE entry per line"));
+    textArgs->setPlaceholderText(AsrProviderDialog::tr("One argument per line"));
+    textEnv->setPlaceholderText(AsrProviderDialog::tr("One KEY=VALUE entry per line"));
     spinTimeout->setRange(1000, 300000);
     spinTimeout->setSingleStep(1000);
     spinTimeout->setSuffix(" ms");
@@ -157,13 +161,13 @@ bool ShowAsrProviderDialog(QWidget* parent, const QString& title, const AsrProvi
                                         spinTimeout);
                      });
 
-    form->addRow(GuiTranslate("Name:"), editName);
-    form->addRow(GuiTranslate("Type:"), comboType);
-    form->addRow(GuiTranslate("Model:"), comboModel);
-    form->addRow(GuiTranslate("Command / Interpreter:"), editCommand);
-    form->addRow(GuiTranslate("Args:"), textArgs);
-    form->addRow(GuiTranslate("Env:"), textEnv);
-    form->addRow(GuiTranslate("Timeout (ms):"), spinTimeout);
+    form->addRow(AsrProviderDialog::tr("Name:"), editName);
+    form->addRow(AsrProviderDialog::tr("Type:"), comboType);
+    form->addRow(AsrProviderDialog::tr("Model:"), comboModel);
+    form->addRow(AsrProviderDialog::tr("Command / Interpreter:"), editCommand);
+    form->addRow(AsrProviderDialog::tr("Args:"), textArgs);
+    form->addRow(AsrProviderDialog::tr("Env:"), textEnv);
+    form->addRow(AsrProviderDialog::tr("Timeout (ms):"), spinTimeout);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
@@ -180,8 +184,8 @@ bool ShowAsrProviderDialog(QWidget* parent, const QString& title, const AsrProvi
     const QString name = editName->text().trimmed();
     const QString type = comboType->currentData().toString();
     if (name.isEmpty()) {
-      QMessageBox::warning(parent, GuiTranslate("Error"),
-                           GuiTranslate("Provider name must not be empty."));
+      QMessageBox::warning(parent, AsrProviderDialog::tr("Error"),
+                           AsrProviderDialog::tr("Provider name must not be empty."));
       continue;
     }
 
@@ -200,8 +204,8 @@ bool ShowAsrProviderDialog(QWidget* parent, const QString& title, const AsrProvi
     {
       const QString command = editCommand->text().trimmed();
       if (command.isEmpty()) {
-        QMessageBox::warning(parent, GuiTranslate("Error"),
-                             GuiTranslate("Command providers require a command."));
+        QMessageBox::warning(parent, AsrProviderDialog::tr("Error"),
+                             AsrProviderDialog::tr("Command providers require a command."));
         continue;
       }
       out_data->command = command.toStdString();
@@ -212,7 +216,7 @@ bool ShowAsrProviderDialog(QWidget* parent, const QString& title, const AsrProvi
       }
       QString env_error;
       if (!ParseCommandEnv(textEnv->toPlainText(), &out_data->env, &env_error)) {
-        QMessageBox::warning(parent, GuiTranslate("Error"), env_error);
+        QMessageBox::warning(parent, AsrProviderDialog::tr("Error"), env_error);
         continue;
       }
     }

--- a/src/gui/dialogs/asr_provider_dialog.cpp
+++ b/src/gui/dialogs/asr_provider_dialog.cpp
@@ -13,6 +13,8 @@
 #include <QSpinBox>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <QtCore/qcoreapplication.h>
+#include <QtWidgets/qmessagebox.h>
 
 #include "config.h"
 #if VINPUT_ENABLE_LOCAL_ASR

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -37,7 +37,6 @@
 
 #include "config.h"
 #include "dialogs/asr_provider_dialog.h"
-#include "utils/gui_helpers.h"
 
 namespace vinput::gui {
 
@@ -392,7 +391,7 @@ void ControlPage::populateAsrList(const CoreConfig& config,
         model = QString::fromStdString(
             vinput::registry::LookupI18n(i18n_map, local->model + ".title", local->model));
       }
-      display += " · " + (model.isEmpty() ? GuiTranslate("(not set)") : model);
+      display += " · " + (model.isEmpty() ? tr("(not set)") : model);
     } else if (const auto* command = std::get_if<CommandAsrProvider>(&provider)) {
       display += " · " + QString::fromStdString(command->command);
     }
@@ -558,7 +557,7 @@ void ControlPage::refreshAdapterList() {
         vinput::registry::LookupI18n(i18n_map, adapter.id + ".title", adapter.id));
     const bool running = vinput::adapter::IsRunning(adapter.id);
 
-    QString display = title + " · " + (running ? GuiTranslate("running") : GuiTranslate("stopped"));
+    QString display = title + " · " + (running ? tr("running") : tr("stopped"));
     display += " · " + (adapter.autoStart ? tr("autostart") : tr("manual"));
     const QString command = QString::fromStdString(adapter.command);
     if (!command.isEmpty()) {
@@ -735,7 +734,7 @@ void ControlPage::onDaemonStart() {
       }
       if (!result.ok()) {
         vinput::cli::NotifyDaemonNotification(result.notification);
-        QMessageBox::critical(self, self->tr("Error"),
+        QMessageBox::critical(self, ControlPage::tr("Error"),
                               QString::fromStdString(result.failure_message));
       }
       self->refreshDaemonStatus();
@@ -772,7 +771,7 @@ void ControlPage::onDaemonRestart() {
       }
       if (!result.ok()) {
         vinput::cli::NotifyDaemonNotification(result.notification);
-        QMessageBox::critical(self, self->tr("Error"),
+        QMessageBox::critical(self, ControlPage::tr("Error"),
                               QString::fromStdString(result.failure_message));
       }
       self->refreshDaemonStatus();

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -110,10 +110,10 @@ constexpr int kDefaultUiLlmMaxCandidates = 3;
 
 QString SceneLabelForGui(const vinput::scene::Definition& scene) {
   if (scene.id == vinput::scene::kRawSceneId || scene.label == vinput::scene::kRawSceneLabelKey)
-    return GuiTranslate("Raw");
+    return LlmPage::tr("Raw");
   if (scene.id == vinput::scene::kCommandSceneId ||
       scene.label == vinput::scene::kCommandSceneLabelKey)
-    return GuiTranslate("Command");
+    return LlmPage::tr("Command");
   if (!scene.label.empty())
     return QString::fromStdString(scene.label);
   return QString::fromStdString(scene.id);
@@ -273,7 +273,7 @@ void LlmPage::refreshAdapterList() {
     QString title = AdapterTitleForGui(adapter.id);
     bool running = vinput::adapter::IsRunning(adapter.id);
 
-    QString display = title + " · " + (running ? GuiTranslate("running") : GuiTranslate("stopped"));
+    QString display = title + " · " + (running ? tr("running") : tr("stopped"));
     display += " · " + (adapter.autoStart ? tr("autostart") : tr("manual"));
     QString command = QString::fromStdString(adapter.command);
     if (!command.isEmpty()) {

--- a/src/gui/pages/resources/resource_page.cpp
+++ b/src/gui/pages/resources/resource_page.cpp
@@ -544,20 +544,20 @@ void ResourcePage::refreshAll() {
           self->remoteAdapters_ = std::move(remote_adapters);
 
           if (!models_error.empty()) {
-            self->textLog_->append(
-                self->tr("Models fetch error: %1").arg(QString::fromStdString(models_error)));
+            self->textLog_->append(ResourcePage::tr("Models fetch error: %1")
+                                       .arg(QString::fromStdString(models_error)));
           }
           if (!providers_error.empty()) {
-            self->textLog_->append(
-                self->tr("Providers fetch error: %1").arg(QString::fromStdString(providers_error)));
+            self->textLog_->append(ResourcePage::tr("Providers fetch error: %1")
+                                       .arg(QString::fromStdString(providers_error)));
           }
           if (!adapters_error.empty()) {
-            self->textLog_->append(
-                self->tr("Adapters fetch error: %1").arg(QString::fromStdString(adapters_error)));
+            self->textLog_->append(ResourcePage::tr("Adapters fetch error: %1")
+                                       .arg(QString::fromStdString(adapters_error)));
           }
           for (const auto& warning : warnings) {
             self->textLog_->append(
-                self->tr("Registry warning: %1").arg(QString::fromStdString(warning)));
+                ResourcePage::tr("Registry warning: %1").arg(QString::fromStdString(warning)));
           }
 
           // Paint remotes with the current map first so rows appear even

--- a/src/gui/utils/gui_helpers.cpp
+++ b/src/gui/utils/gui_helpers.cpp
@@ -21,9 +21,11 @@
 
 namespace vinput::gui {
 
-QString GuiTranslate(const char* sourceText) {
-  return QCoreApplication::translate("MainWindow", sourceText);
-}
+namespace {
+struct GuiHelpers {
+  Q_DECLARE_TR_FUNCTIONS(GuiHelpers)
+};
+} // namespace
 
 QStringList NonEmptyLines(const QString& text) {
   QStringList lines;
@@ -47,7 +49,7 @@ QTableWidgetItem* MakeCell(const QString& text, const QString& data) {
 bool ValidateProviderInput(const QString& name, const QString& base_url, QString* error_out) {
   if (name.trimmed().isEmpty()) {
     if (error_out) {
-      *error_out = GuiTranslate("Provider name must not be empty.");
+      *error_out = GuiHelpers::tr("Provider name must not be empty.");
     }
     return false;
   }
@@ -56,7 +58,7 @@ bool ValidateProviderInput(const QString& name, const QString& base_url, QString
   if (!url.isValid() || url.scheme().isEmpty() || url.host().isEmpty() ||
       (url.scheme() != "http" && url.scheme() != "https")) {
     if (error_out) {
-      *error_out = GuiTranslate("Base URL must be a valid http:// or https:// URL.");
+      *error_out = GuiHelpers::tr("Base URL must be a valid http:// or https:// URL.");
     }
     return false;
   }
@@ -75,7 +77,7 @@ bool ParseCommandEnv(const QString& text, std::map<std::string, std::string>* en
     const int pos = line.indexOf('=');
     if (pos <= 0) {
       if (error_out) {
-        *error_out = GuiTranslate("Invalid env entry '%1'. Use KEY=VALUE.").arg(line);
+        *error_out = GuiHelpers::tr("Invalid env entry '%1'. Use KEY=VALUE.").arg(line);
       }
       return false;
     }
@@ -106,7 +108,7 @@ void ApplyFetchedProviderModels(QComboBox* comboModel, const QStringList& models
   comboModel->setToolTip(QString());
   if (auto* lineEdit = comboModel->lineEdit()) {
     lineEdit->setPlaceholderText(
-        models.isEmpty() ? GuiTranslate("No models returned. You can type one manually.")
+        models.isEmpty() ? GuiHelpers::tr("No models returned. You can type one manually.")
                          : QString());
   }
   comboModel->addItems(models);
@@ -124,8 +126,8 @@ void ApplyProviderModelFetchError(QComboBox* comboModel, const QString& error) {
   comboModel->setToolTip(error);
   if (auto* lineEdit = comboModel->lineEdit()) {
     lineEdit->setPlaceholderText(
-        GuiTranslate("Failed to load models. Type one manually or reselect "
-                     "the provider to retry."));
+        GuiHelpers::tr("Failed to load models. Type one manually or reselect "
+                       "the provider to retry."));
   }
 
   const QString desiredModel = comboModel->property("vinput_desired_model").toString();
@@ -162,7 +164,7 @@ void FetchModelsFromProviderAsync(const ProviderInfo& provider, QComboBox* combo
   comboModel->clear();
   comboModel->setToolTip(QString());
   if (auto* lineEdit = comboModel->lineEdit()) {
-    lineEdit->setPlaceholderText(GuiTranslate("Loading models..."));
+    lineEdit->setPlaceholderText(GuiHelpers::tr("Loading models..."));
   }
 
   const std::string url_str =
@@ -206,7 +208,7 @@ void FetchModelsFromProviderAsync(const ProviderInfo& provider, QComboBox* combo
           const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll(), &parseError);
           if (parseError.error != QJsonParseError::NoError || !doc.isObject() ||
               !doc.object().value("data").isArray()) {
-            error = GuiTranslate("Provider returned invalid JSON for /v1/models.");
+            error = GuiHelpers::tr("Provider returned invalid JSON for /v1/models.");
           } else {
             const QJsonArray data = doc.object().value("data").toArray();
             for (const auto& v : data) {

--- a/src/gui/utils/gui_helpers.cpp
+++ b/src/gui/utils/gui_helpers.cpp
@@ -11,6 +11,7 @@
 #include <QNetworkRequest>
 #include <QTimer>
 #include <QUrl>
+#include <QtCore/qcoreapplication.h>
 #include <vector>
 
 #include "common/llm/defaults.h"

--- a/src/gui/utils/gui_helpers.h
+++ b/src/gui/utils/gui_helpers.h
@@ -7,9 +7,6 @@
 
 namespace vinput::gui {
 
-// Translate helper for non-QObject contexts.
-QString GuiTranslate(const char* sourceText);
-
 // Split text into non-empty trimmed lines.
 QStringList NonEmptyLines(const QString& text);
 


### PR DESCRIPTION
Closes #159

### Implementation Tasks
- [x] 1. Add 23 missing GuiTranslate entries to i18n/vinput-gui_zh_CN.ts (MainWindow context)
- [x] 2. Load Qt base translations in GUI main.cpp so QDialogButtonBox standard buttons (OK/Cancel) follow system language
- [x] 3. check-i18n.py: find Arch's lupdate6 binary so Qt .ts checks run locally
- [x] 4. Refactor: replace GuiTranslate with standard Q_DECLARE_TR_FUNCTIONS / Class::tr and fix self->tr() in lambdas
- [x] 5. Clean up redundant/obsolete entries in TS and PO, add missing PO translation, and enhance check-i18n.py

### Validation
- scripts/check-i18n.py now fully green locally across both po and ts:
  - po: 0 missing, 0 obsolete, 0 untranslated (includes daemon, supports multiline msgids, rejects dead PO entries)
  - ts: 0 missing, 0 vanished, 0 untranslated (all 220 messages automatically extracted by lupdate, 0 lupdate warnings)
- lrelease6 compiles the ts cleanly into qm: 220 translations, 0 unfinished.
- Full, Lite, Nix Lite, and cpp-linter CI all passed on previous commits.