### PR TITLE
feat(scene): allow empty prompt in postprocess definition (#161)

### DIFF
--- a/src/common/scene/postprocess_scene.cpp
+++ b/src/common/scene/postprocess_scene.cpp
@@ -17,10 +17,6 @@ bool HasModel(const Definition& scene) {
   return !scene.model.empty();
 }
 
-bool HasPrompt(const Definition& scene) {
-  return !scene.prompt.empty();
-}
-
 bool SetValidationError(std::string* error, std::string message) {
   if (error) {
     *error = std::move(message);
@@ -99,9 +95,6 @@ bool ValidateDefinition(const Definition& scene, std::string* error, bool requir
   const bool has_model = HasModel(scene);
   if (has_provider != has_model) {
     return SetValidationError(error, "Scene provider and model must be configured together.");
-  }
-  if ((has_provider || has_model) && !HasPrompt(scene)) {
-    return SetValidationError(error, "Scene prompt must not be empty when provider/model is set.");
   }
   return true;
 }

--- a/src/daemon/postprocess/post_processor.cpp
+++ b/src/daemon/postprocess/post_processor.cpp
@@ -289,10 +289,6 @@ RewriteWithOpenAiCompatible(const std::string& text, const vinput::scene::Defini
                             std::string* error_out, const std::string& task_prompt = {},
                             const std::atomic<bool>* cancel_flag = nullptr,
                             std::string_view asr_var = {}, std::string_view selected_var = {}) {
-  if (scene.prompt.empty() && task_prompt.empty()) {
-    return std::nullopt;
-  }
-
   CurlGuard guard;
   guard.curl = curl_easy_init();
   if (!guard.curl) {
@@ -525,7 +521,7 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
   fallback.commitText = normalized;
 
   const LlmProvider* provider = ResolveLlmProvider(settings, scene.provider_id);
-  if (provider == nullptr || max_llm_candidates == 0 || scene.prompt.empty()) {
+  if (provider == nullptr || max_llm_candidates == 0) {
     return fallback;
   }
 

--- a/src/daemon/runtime/recognition_pipeline.cpp
+++ b/src/daemon/runtime/recognition_pipeline.cpp
@@ -71,8 +71,7 @@ RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& se
   }
 
   const auto& scene = vinput::scene::Resolve(scene_config, order.scene_id);
-  if (scene.llm_max_candidates > 0 && !scene.provider_id.empty() && !scene.prompt.empty() &&
-      on_enter_postprocessing) {
+  if (scene.llm_max_candidates > 0 && !scene.provider_id.empty() && on_enter_postprocessing) {
     on_enter_postprocessing();
   }
 


### PR DESCRIPTION
Closes #161

### Implementation Tasks
- [x] 1. Core validation: remove mandatory prompt check in src/common/scene/postprocess_scene.cpp
- [x] 2. Daemon pipeline: allow empty prompt in recognition_pipeline.cpp and post_processor.cpp

### Validation
- Local lightweight quality gates (clang-format, hk, check-i18n.py) all passed.
- Tested scene validation and daemon post-processing code paths: empty prompt cleanly sends text wrapped in <vinput_asr> to provider/adapter without dummy placeholder prompt.