### PR TITLE
feat(addon): show transcript during post-processing

### DIFF
--- a/po/fcitx5-vinput.pot
+++ b/po/fcitx5-vinput.pot
@@ -29,6 +29,13 @@ msgstr ""
 msgid "... Postprocessing ..."
 msgstr ""
 
+msgid "... Applying command ..."
+msgstr ""
+
+#, c-format
+msgid "Command: %s"
+msgstr ""
+
 msgid ""
 "Local ASR model configuration is missing. Please configure a model first."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -37,6 +37,13 @@ msgstr "语音输入守护进程不可用。"
 msgid "Voice input daemon is not responding."
 msgstr "语音输入守护进程无响应。"
 
+msgid "... Applying command ..."
+msgstr "... 正在应用命令 ..."
+
+#, c-format
+msgid "Command: %s"
+msgstr "命令：%s"
+
 msgid ""
 "Local ASR model configuration is missing. Please configure a model first."
 msgstr "本地 ASR 模型配置缺失。请先配置模型。"

--- a/src/addon/core/vinput.cpp
+++ b/src/addon/core/vinput.cpp
@@ -118,6 +118,7 @@ VinputEngine::VinputEngine(fcitx::Instance* instance) : instance_(instance) {
                               auto* ic = icEvent.inputContext();
                               if (session_ && session_->ic == ic) {
                                 session_.reset();
+                                polled_idle_since_.reset();
                               }
                               if (status_ic_ == ic) {
                                 status_ic_ = nullptr;

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -89,15 +89,18 @@ private:
   void enterPendingStartState(fcitx::InputContext* ic, const fcitx::Key& trigger,
                               bool command_mode);
   void enterRecordingState(fcitx::InputContext* ic, const fcitx::Key& trigger, bool command_mode);
-  void enterBusyState(fcitx::InputContext* ic, bool command_mode, const std::string& preedit_text);
+  void enterBusyState(fcitx::InputContext* ic, bool command_mode, const std::string& preedit_text,
+                      bool postprocessing = false);
   void finishFrontendSession(fcitx::InputContext* fallback_ic = nullptr);
   void syncFrontendWithDaemonStatus(fcitx::InputContext* fallback_ic = nullptr,
                                     bool prefer_command_mode = false);
   void rememberInputContext(fcitx::InputContext* ic);
   fcitx::InputContext*
   resolveFrontendInputContext(fcitx::InputContext* fallback_ic = nullptr) const;
-  void updatePreedit(fcitx::InputContext* ic, const std::string& text);
-  void clearPreedit(fcitx::InputContext* ic);
+  void dismissMenusForVoiceActivity();
+  void updateVoicePresentation(fcitx::InputContext* ic, const std::string& preedit_text,
+                               const std::string& aux_down_text = {});
+  void clearVoicePresentation(fcitx::InputContext* ic);
   void appendContextEntry(const std::string& text, const char* source);
   void flushContextBuffer();
   void accumulateContextBuffer(const std::string& text, fcitx::InputContext* ic);
@@ -116,14 +119,14 @@ private:
   std::unique_ptr<fcitx::dbus::Slot> pending_start_call_slot_;
   std::unique_ptr<fcitx::dbus::Slot> pending_stop_call_slot_;
   struct Session {
-    enum class Phase { PendingStart, Recording, Busy };
+    enum class Phase : std::uint8_t { PendingStart, Recording, Inferring, Postprocessing };
     Phase phase;
     fcitx::InputContext* ic;
     fcitx::Key trigger;
     std::chrono::steady_clock::time_point press_time;
     bool command_mode = false;
     bool trigger_released = false;
-    std::string partial_text;
+    std::string transcript_text;
   };
   std::optional<Session> session_;
   fcitx::InputContext* status_ic_ = nullptr;
@@ -160,6 +163,7 @@ private:
   std::chrono::steady_clock::time_point last_trigger_time_;
   std::chrono::steady_clock::time_point daemon_sync_blocked_until_{};
   std::string last_known_daemon_status_;
+  std::optional<std::chrono::steady_clock::time_point> polled_idle_since_;
   vinput::dbus::AsrBackendState cached_asr_backend_state_;
   bool has_cached_asr_backend_state_ = false;
   std::atomic<uint64_t> asr_state_refresh_seq_{0};

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <cstdio>
 #include <fcitx-utils/dbus/matchrule.h>
 #include <fcitx-utils/dbus/message.h>
@@ -7,6 +8,7 @@
 #include <tuple>
 
 #include "common/asr/recognition_result.h"
+#include "common/config/vinput_config.h"
 #include "common/dbus/dbus_interface.h"
 #include "common/dbus/error_info.h"
 #include "common/i18n.h"
@@ -23,6 +25,8 @@ using namespace vinput::dbus;
 namespace {
 
 constexpr uint64_t kStatusSyncIntervalUsec = 200 * 1000;
+constexpr auto kPolledIdleRecoveryDelay =
+    std::chrono::milliseconds(vinput::runtime::kDbusCallTimeoutMs);
 std::string StartingPreeditText() {
   return _("... Starting ...");
 }
@@ -42,6 +46,14 @@ std::string PostprocessingPreeditText() {
   return _("... Postprocessing ...");
 }
 
+std::string ApplyingCommandPreeditText() {
+  return _("... Applying command ...");
+}
+
+std::string CommandTranscriptPreeditText(const std::string& text) {
+  return vinput::str::FmtStr(_("Command: %s"), text.c_str());
+}
+
 std::string DaemonUnavailablePreeditText() {
   return _("Voice input daemon is unavailable.");
 }
@@ -50,20 +62,20 @@ std::string DaemonNotRespondingPreeditText() {
   return _("Voice input daemon is not responding.");
 }
 
-std::string ComposeLivePreedit(bool command_mode, bool recording, const std::string& partial_text,
-                               const std::string& fallback_text, int max_display_width = 0) {
-  (void)command_mode;
-  (void)recording;
-  if (partial_text.empty()) {
+std::string LimitPreviewText(const std::string& text, int max_display_width) {
+  if (max_display_width <= 0) {
+    return text;
+  }
+  return vinput::str::TruncateMiddleUtf8(text, static_cast<size_t>(max_display_width), "...");
+}
+
+std::string ComposeLivePreedit(const std::string& transcript_text, const std::string& fallback_text,
+                               int max_display_width = 0) {
+  if (transcript_text.empty()) {
     return fallback_text;
   }
 
-  if (max_display_width > 0) {
-    return vinput::str::TruncateMiddleUtf8(partial_text, static_cast<size_t>(max_display_width),
-                                           "...");
-  }
-
-  return partial_text;
+  return LimitPreviewText(transcript_text, max_display_width);
 }
 
 std::string AppendDetail(std::string summary, const std::string& detail) {
@@ -337,10 +349,10 @@ bool VinputEngine::callStartRecording() {
           auto* ic = resolveFrontendInputContext();
           finishFrontendSession(ic);
           if (ic) {
-            updatePreedit(ic, reply
-                                  ? RenderMethodCallFailure(reply.errorName(), reply.errorMessage(),
-                                                            DaemonUnavailablePreeditText())
-                                  : DaemonUnavailablePreeditText());
+            updateVoicePresentation(
+                ic, reply ? RenderMethodCallFailure(reply.errorName(), reply.errorMessage(),
+                                                    DaemonUnavailablePreeditText())
+                          : DaemonUnavailablePreeditText());
           }
           return true;
         }
@@ -373,10 +385,10 @@ bool VinputEngine::callStartCommandRecording(const std::string& selected_text) {
           auto* ic = resolveFrontendInputContext();
           finishFrontendSession(ic);
           if (ic) {
-            updatePreedit(ic, reply
-                                  ? RenderMethodCallFailure(reply.errorName(), reply.errorMessage(),
-                                                            DaemonUnavailablePreeditText())
-                                  : DaemonUnavailablePreeditText());
+            updateVoicePresentation(
+                ic, reply ? RenderMethodCallFailure(reply.errorName(), reply.errorMessage(),
+                                                    DaemonUnavailablePreeditText())
+                          : DaemonUnavailablePreeditText());
           }
           return true;
         }
@@ -406,10 +418,10 @@ bool VinputEngine::callStopRecording(const std::string& scene_id) {
           auto* ic = resolveFrontendInputContext();
           finishFrontendSession(ic);
           if (ic) {
-            updatePreedit(ic, reply
-                                  ? RenderMethodCallFailure(reply.errorName(), reply.errorMessage(),
-                                                            DaemonUnavailablePreeditText())
-                                  : DaemonUnavailablePreeditText());
+            updateVoicePresentation(
+                ic, reply ? RenderMethodCallFailure(reply.errorName(), reply.errorMessage(),
+                                                    DaemonUnavailablePreeditText())
+                          : DaemonUnavailablePreeditText());
           }
           return true;
         }
@@ -461,7 +473,7 @@ void VinputEngine::enterPendingStartState(fcitx::InputContext* ic, const fcitx::
   }
   rememberInputContext(ic);
   if (status_ic_ && status_ic_ != ic) {
-    clearPreedit(status_ic_);
+    clearVoicePresentation(status_ic_);
   }
   if (!session_) {
     session_.emplace(Session{Session::Phase::PendingStart,
@@ -478,8 +490,8 @@ void VinputEngine::enterPendingStartState(fcitx::InputContext* ic, const fcitx::
     session_->command_mode = command_mode;
   }
   status_ic_ = ic;
-  updatePreedit(ic, ComposeLivePreedit(command_mode, false, {}, StartingPreeditText(),
-                                       max_streaming_display_width_));
+  updateVoicePresentation(
+      ic, ComposeLivePreedit({}, StartingPreeditText(), max_streaming_display_width_));
   ensureStatusSync();
 }
 
@@ -490,8 +502,11 @@ void VinputEngine::enterRecordingState(fcitx::InputContext* ic, const fcitx::Key
   }
   rememberInputContext(ic);
   if (status_ic_ && status_ic_ != ic) {
-    clearPreedit(status_ic_);
+    clearVoicePresentation(status_ic_);
   }
+  const bool stop_after_start = trigger_mode_ == TriggerMode::Hold && session_ &&
+                                session_->phase == Session::Phase::PendingStart &&
+                                session_->trigger_released;
   if (!session_) {
     session_.emplace(Session{Session::Phase::Recording,
                              ic,
@@ -507,52 +522,60 @@ void VinputEngine::enterRecordingState(fcitx::InputContext* ic, const fcitx::Key
     session_->command_mode = command_mode;
   }
   status_ic_ = ic;
-  updatePreedit(
-      ic, ComposeLivePreedit(command_mode, true, session_ ? session_->partial_text : std::string{},
+  updateVoicePresentation(
+      ic, ComposeLivePreedit(session_ ? session_->transcript_text : std::string{},
                              command_mode ? CommandingPreeditText() : RecordingPreeditText(),
                              max_streaming_display_width_));
   ensureStatusSync();
+  if (stop_after_start) {
+    scheduleStopRecording();
+  }
 }
 
 void VinputEngine::enterBusyState(fcitx::InputContext* ic, bool command_mode,
-                                  const std::string& preedit_text) {
+                                  const std::string& preedit_text, bool postprocessing) {
   if (!ic) {
     return;
   }
   rememberInputContext(ic);
   if (status_ic_ && status_ic_ != ic) {
-    clearPreedit(status_ic_);
+    clearVoicePresentation(status_ic_);
   }
+  const auto phase = postprocessing ? Session::Phase::Postprocessing : Session::Phase::Inferring;
   if (!session_) {
-    session_.emplace(Session{Session::Phase::Busy,
-                             ic,
-                             fcitx::Key(),
-                             std::chrono::steady_clock::now(),
-                             command_mode,
-                             {},
-                             {}});
+    session_.emplace(
+        Session{phase, ic, fcitx::Key(), std::chrono::steady_clock::now(), command_mode, {}, {}});
   } else {
-    session_->phase = Session::Phase::Busy;
+    session_->phase = phase;
     session_->ic = ic;
     session_->trigger = fcitx::Key();
     session_->command_mode = command_mode;
   }
   status_ic_ = ic;
-  updatePreedit(ic, ComposeLivePreedit(command_mode, false,
-                                       session_ ? session_->partial_text : std::string{},
-                                       preedit_text, max_streaming_display_width_));
+  if (postprocessing && !session_->transcript_text.empty()) {
+    const auto transcript =
+        LimitPreviewText(command_mode ? CommandTranscriptPreeditText(session_->transcript_text)
+                                      : session_->transcript_text,
+                         max_streaming_display_width_);
+    updateVoicePresentation(ic, command_mode ? ApplyingCommandPreeditText() : preedit_text,
+                            transcript);
+  } else {
+    updateVoicePresentation(ic, ComposeLivePreedit(session_->transcript_text, preedit_text,
+                                                   max_streaming_display_width_));
+  }
   ensureStatusSync();
 }
 
 void VinputEngine::finishFrontendSession(fcitx::InputContext* fallback_ic) {
   auto* ic = session_ ? session_->ic : (fallback_ic ? fallback_ic : status_ic_);
   session_.reset();
+  polled_idle_since_.reset();
   command_selected_text_.clear();
   if (status_ic_ == ic) {
     status_ic_ = nullptr;
   }
   if (ic) {
-    clearPreedit(ic);
+    clearVoicePresentation(ic);
   }
   stopStatusSyncIfIdle();
 }
@@ -715,12 +738,27 @@ void VinputEngine::syncFrontendWithDaemonStatus(fcitx::InputContext* fallback_ic
     return;
   }
 
+  if (status == kStatusIdle && session_) {
+    const auto now = std::chrono::steady_clock::now();
+    if (!polled_idle_since_) {
+      polled_idle_since_ = now;
+    }
+    if (now - *polled_idle_since_ < kPolledIdleRecoveryDelay) {
+      return;
+    }
+  }
+  polled_idle_since_.reset();
+
   applyDaemonStatusLocally(status, fallback_ic, prefer_command_mode);
 }
 
 void VinputEngine::applyDaemonStatusLocally(const std::string& status,
                                             fcitx::InputContext* fallback_ic,
                                             bool prefer_command_mode) {
+  if (status == kStatusIdle && !session_ && status_ic_ == nullptr) {
+    return;
+  }
+
   auto* ic = resolveFrontendInputContext(fallback_ic);
   if (!ic) {
     return;
@@ -740,7 +778,7 @@ void VinputEngine::applyDaemonStatusLocally(const std::string& status,
 
   if (status == kStatusPostprocessing) {
     enterBusyState(ic, session_ ? session_->command_mode : prefer_command_mode,
-                   PostprocessingPreeditText());
+                   PostprocessingPreeditText(), true);
     return;
   }
 
@@ -761,8 +799,6 @@ void VinputEngine::onRecognitionResult(fcitx::dbus::Message& msg) {
   }
 
   rememberInputContext(ic);
-
-  hideResultMenu();
 
   const auto payload = vinput::result::Parse(payload_text);
   finishFrontendSession(ic);
@@ -836,8 +872,12 @@ void VinputEngine::onRecognitionResult(fcitx::dbus::Message& msg) {
 }
 
 void VinputEngine::onRecognitionPartial(fcitx::dbus::Message& msg) {
-  std::string partial_text;
-  msg >> partial_text;
+  std::string transcript_text;
+  msg >> transcript_text;
+
+  if (!session_ || transcript_text.empty()) {
+    return;
+  }
 
   auto* ic = resolveFrontendInputContext();
   if (!ic) {
@@ -845,24 +885,23 @@ void VinputEngine::onRecognitionPartial(fcitx::dbus::Message& msg) {
   }
 
   rememberInputContext(ic);
+  session_->transcript_text = transcript_text;
+  if (session_->phase == Session::Phase::Postprocessing) {
+    enterBusyState(ic, session_->command_mode, PostprocessingPreeditText(), true);
+    return;
+  }
 
-  if (session_) {
-    session_->partial_text = partial_text;
-  }
-  if (!partial_text.empty()) {
-    updatePreedit(ic, ComposeLivePreedit(
-                          session_ ? session_->command_mode : false,
-                          session_ && session_->phase == Session::Phase::Recording, partial_text,
-                          session_ && session_->command_mode ? CommandingPreeditText()
-                                                             : RecordingPreeditText(),
-                          max_streaming_display_width_));
-  }
+  updateVoicePresentation(ic, ComposeLivePreedit(transcript_text,
+                                                 session_->command_mode ? CommandingPreeditText()
+                                                                        : RecordingPreeditText(),
+                                                 max_streaming_display_width_));
 }
 
 void VinputEngine::onStatusChanged(fcitx::dbus::Message& msg) {
   std::string status;
   msg >> status;
   last_known_daemon_status_ = status;
+  polled_idle_since_.reset();
 
   auto* ic = resolveFrontendInputContext();
   if (ic) {
@@ -884,7 +923,6 @@ void VinputEngine::onDaemonNotification(fcitx::dbus::Message& msg) {
 
   if (IsErrorLikeNotification(notification)) {
     auto* ic = resolveFrontendInputContext();
-    hideResultMenu();
     finishFrontendSession(ic);
   }
 
@@ -953,21 +991,26 @@ void VinputEngine::notifyInfo(const std::string& message) {
   }
 }
 
-void VinputEngine::updatePreedit(fcitx::InputContext* ic, const std::string& text) {
+void VinputEngine::dismissMenusForVoiceActivity() {
+  hidePaletteMenu();
+  hideResultMenu();
+}
+
+void VinputEngine::updateVoicePresentation(fcitx::InputContext* ic, const std::string& preedit_text,
+                                           const std::string& aux_down_text) {
   if (!ic)
     return;
+  dismissMenusForVoiceActivity();
   fcitx::Text preedit;
-  preedit.append(text);
+  preedit.append(preedit_text);
+  fcitx::Text aux_down;
+  aux_down.append(aux_down_text);
   ic->inputPanel().setPreedit(preedit);
+  ic->inputPanel().setAuxDown(aux_down);
   ic->updatePreedit();
   ic->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
 }
 
-void VinputEngine::clearPreedit(fcitx::InputContext* ic) {
-  if (!ic)
-    return;
-  fcitx::Text empty;
-  ic->inputPanel().setPreedit(empty);
-  ic->updatePreedit();
-  ic->updateUserInterface(fcitx::UserInterfaceComponent::InputPanel);
+void VinputEngine::clearVoicePresentation(fcitx::InputContext* ic) {
+  updateVoicePresentation(ic, {});
 }

--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "common/config/core_config.h"
+#include "common/config/vinput_config.h"
 #include "common/dbus/dbus_interface.h"
 #include "common/i18n.h"
 #include "common/scene/postprocess_scene.h"
@@ -42,30 +43,44 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
   auto& keyEvent = static_cast<fcitx::KeyEvent&>(event);
   rememberInputContext(keyEvent.inputContext());
 
-  if (result_menu_visible_ && handleResultMenuKeyEvent(keyEvent)) {
-    return;
-  }
-
-  if (palette_menu_visible_ && handlePaletteMenuKeyEvent(keyEvent)) {
-    return;
-  }
-
-  if (!session_ && keyEvent.key().checkKeyList(menu_keys_) && !keyEvent.isRelease()) {
-    showPaletteMenu(keyEvent.inputContext());
-    keyEvent.filterAndAccept();
-    return;
-  }
-
-  if (keyEvent.key().checkKeyList(menu_keys_) && keyEvent.isRelease()) {
-    keyEvent.filterAndAccept();
-    return;
-  }
-
   const int trigger_index = keyEvent.key().keyListIndex(trigger_keys_);
   const bool is_trigger = trigger_index >= 0;
-
   const int command_index = keyEvent.key().keyListIndex(command_keys_);
   const bool is_command = command_index >= 0;
+  const bool voice_trigger_press = (is_trigger || is_command) && !keyEvent.isRelease();
+  const bool voice_start_pending = pending_start_event_ && pending_start_event_->isEnabled();
+
+  if (trigger_mode_ == TriggerMode::Hold && (is_trigger || is_command) && keyEvent.isRelease() &&
+      voice_start_pending) {
+    cancelPendingStart();
+    keyEvent.filterAndAccept();
+    return;
+  }
+
+  if (!voice_trigger_press) {
+    if (result_menu_visible_ && handleResultMenuKeyEvent(keyEvent)) {
+      return;
+    }
+
+    if (palette_menu_visible_ && handlePaletteMenuKeyEvent(keyEvent)) {
+      return;
+    }
+
+    if (!is_trigger && !is_command) {
+      if (!session_ && keyEvent.key().checkKeyList(menu_keys_) && !keyEvent.isRelease()) {
+        if (!voice_start_pending) {
+          showPaletteMenu(keyEvent.inputContext());
+        }
+        keyEvent.filterAndAccept();
+        return;
+      }
+
+      if (keyEvent.key().checkKeyList(menu_keys_) && keyEvent.isRelease()) {
+        keyEvent.filterAndAccept();
+        return;
+      }
+    }
+  }
 
   FCITX_LOG(Debug) << "vinput handleKeyEvent: " << keyEvent.key()
                    << " is_release=" << keyEvent.isRelease() << " is_trigger=" << is_trigger
@@ -80,6 +95,7 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
       return;
     }
 
+    dismissMenusForVoiceActivity();
     cancelPendingStop();
 
     if (session_ && session_->phase == Session::Phase::Recording && session_->trigger_released) {
@@ -100,8 +116,6 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
     if (trigger_mode_ == TriggerMode::Hold) {
       const std::string daemon_status = last_known_daemon_status_;
       if (is_trigger && !session_ && daemon_status == vinput::dbus::kStatusRecording) {
-        hideResultMenu();
-        hidePaletteMenu();
         enterRecordingState(ic, trigger, false);
         finishStopRecording();
         keyEvent.filterAndAccept();
@@ -121,23 +135,20 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
       pending_start_event_ = instance_->eventLoop().addTimeEvent(
           CLOCK_MONOTONIC, fire_at_usec, 0,
           [this, ic, trigger, is_command](fcitx::EventSourceTime*, uint64_t) {
-            hideResultMenu();
-            hidePaletteMenu();
-
             if (is_command) {
               {
                 auto core_config = LoadCoreConfig();
                 const auto* cmd_scene = FindCommandScene(core_config);
                 if (cmd_scene == nullptr || cmd_scene->llm_max_candidates <= 0) {
                   finishFrontendSession(ic);
-                  updatePreedit(ic, CommandDisabledPreeditText());
+                  updateVoicePresentation(ic, CommandDisabledPreeditText());
                   pending_start_event_.reset();
                   return false;
                 }
                 if (cmd_scene->provider_id.empty() ||
                     ResolveLlmProvider(core_config, cmd_scene->provider_id) == nullptr) {
                   finishFrontendSession(ic);
-                  updatePreedit(ic, CommandNoProviderPreeditText());
+                  updateVoicePresentation(ic, CommandNoProviderPreeditText());
                   pending_start_event_.reset();
                   return false;
                 }
@@ -167,11 +178,11 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
                 if (status_ic_ == ic) {
                   finishFrontendSession(ic);
                 } else {
-                  clearPreedit(ic);
+                  clearVoicePresentation(ic);
                 }
                 vinput::debug::Log("command trigger ignored because no selection text is "
                                    "available\n");
-                updatePreedit(ic, NoSelectionPreeditText());
+                updateVoicePresentation(ic, NoSelectionPreeditText());
                 pending_start_event_.reset();
                 return false;
               }
@@ -182,11 +193,11 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
                 finishFrontendSession(ic);
                 if (!bus_) {
                   vinput::debug::Log("command trigger fallback: daemon bus unavailable\n");
-                  updatePreedit(ic, DaemonUnavailablePreeditText());
+                  updateVoicePresentation(ic, DaemonUnavailablePreeditText());
                 } else if (!daemonSyncAllowed()) {
                   vinput::debug::Log("command trigger fallback: daemon sync throttled "
                                      "after timeout/failure\n");
-                  updatePreedit(ic, DaemonNotRespondingPreeditText());
+                  updateVoicePresentation(ic, DaemonNotRespondingPreeditText());
                 }
               }
             } else {
@@ -196,11 +207,11 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
                 finishFrontendSession(ic);
                 if (!bus_) {
                   vinput::debug::Log("record trigger fallback: daemon bus unavailable\n");
-                  updatePreedit(ic, DaemonUnavailablePreeditText());
+                  updateVoicePresentation(ic, DaemonUnavailablePreeditText());
                 } else if (!daemonSyncAllowed()) {
                   vinput::debug::Log("record trigger fallback: daemon sync throttled "
                                      "after timeout/failure\n");
-                  updatePreedit(ic, DaemonNotRespondingPreeditText());
+                  updateVoicePresentation(ic, DaemonNotRespondingPreeditText());
                 }
               }
             }
@@ -215,8 +226,6 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
     // Tap / Both mode: start immediately on press
     const std::string daemon_status = last_known_daemon_status_;
     if (is_trigger && !session_ && daemon_status == vinput::dbus::kStatusRecording) {
-      hideResultMenu();
-      hidePaletteMenu();
       enterRecordingState(ic, trigger, false);
       finishStopRecording();
       keyEvent.filterAndAccept();
@@ -227,9 +236,6 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
       keyEvent.filterAndAccept();
       return;
     }
-    hideResultMenu();
-    hidePaletteMenu();
-
     if (is_command) {
       // Check command scene has llm_max_candidates > 0 and a valid provider
       {
@@ -237,14 +243,14 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
         const auto* cmd_scene = FindCommandScene(core_config);
         if (cmd_scene == nullptr || cmd_scene->llm_max_candidates <= 0) {
           finishFrontendSession(ic);
-          updatePreedit(ic, CommandDisabledPreeditText());
+          updateVoicePresentation(ic, CommandDisabledPreeditText());
           keyEvent.filterAndAccept();
           return;
         }
         if (cmd_scene->provider_id.empty() ||
             ResolveLlmProvider(core_config, cmd_scene->provider_id) == nullptr) {
           finishFrontendSession(ic);
-          updatePreedit(ic, CommandNoProviderPreeditText());
+          updateVoicePresentation(ic, CommandNoProviderPreeditText());
           keyEvent.filterAndAccept();
           return;
         }
@@ -274,10 +280,10 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
         if (status_ic_ == ic) {
           finishFrontendSession(ic);
         } else {
-          clearPreedit(ic);
+          clearVoicePresentation(ic);
         }
         vinput::debug::Log("command trigger ignored because no selection text is available\n");
-        updatePreedit(ic, NoSelectionPreeditText());
+        updateVoicePresentation(ic, NoSelectionPreeditText());
         keyEvent.filterAndAccept();
         return;
       }
@@ -288,11 +294,11 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
         finishFrontendSession(ic);
         if (!bus_) {
           vinput::debug::Log("command trigger fallback: daemon bus unavailable\n");
-          updatePreedit(ic, DaemonUnavailablePreeditText());
+          updateVoicePresentation(ic, DaemonUnavailablePreeditText());
         } else if (!daemonSyncAllowed()) {
           vinput::debug::Log("command trigger fallback: daemon sync throttled "
                              "after timeout/failure\n");
-          updatePreedit(ic, DaemonNotRespondingPreeditText());
+          updateVoicePresentation(ic, DaemonNotRespondingPreeditText());
         }
       }
     } else {
@@ -302,11 +308,11 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
         finishFrontendSession(ic);
         if (!bus_) {
           vinput::debug::Log("record trigger fallback: daemon bus unavailable\n");
-          updatePreedit(ic, DaemonUnavailablePreeditText());
+          updateVoicePresentation(ic, DaemonUnavailablePreeditText());
         } else if (!daemonSyncAllowed()) {
           vinput::debug::Log("record trigger fallback: daemon sync throttled "
                              "after timeout/failure\n");
-          updatePreedit(ic, DaemonNotRespondingPreeditText());
+          updateVoicePresentation(ic, DaemonNotRespondingPreeditText());
         }
       }
     }
@@ -321,11 +327,10 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
       keyEvent.filterAndAccept();
       return;
     }
-    if (session_ && session_->phase == Session::Phase::Recording &&
-        isReleaseOfActiveTrigger(keyEvent.key())) {
+    if (session_ && isReleaseOfActiveTrigger(keyEvent.key())) {
+      const bool recording = session_->phase == Session::Phase::Recording;
       session_->trigger_released = true;
-      auto held = std::chrono::steady_clock::now() - session_->press_time;
-      if (held >= kToggleThreshold) {
+      if (recording) {
         scheduleStopRecording();
       }
     }
@@ -433,7 +438,6 @@ void VinputEngine::finishStopRecording() {
   }
   const auto& scene = vinput::scene::Resolve(scene_config_, active_scene_id_);
   active_scene_id_ = scene.id;
-  session_->phase = Session::Phase::Busy;
   session_->trigger = fcitx::Key();
   enterBusyState(session_->ic, session_->command_mode, _("... Recognizing ..."));
   callStopRecording(scene.id);

--- a/src/daemon/runtime/daemon_runtime_controller.cpp
+++ b/src/daemon/runtime/daemon_runtime_controller.cpp
@@ -117,30 +117,6 @@ void ApplyRecognitionEvents(
   }
 }
 
-void EmitRecognitionEvents(const std::vector<vinput::daemon::asr::RecognitionEvent>& events,
-                           DbusService* dbus) {
-  if (!dbus) {
-    return;
-  }
-  for (const auto& event : events) {
-    switch (event.kind) {
-    case vinput::daemon::asr::RecognitionEventKind::PartialText:
-    case vinput::daemon::asr::RecognitionEventKind::FinalText:
-      if (!event.text.empty()) {
-        dbus->EmitRecognitionPartial(event.text);
-      }
-      break;
-    case vinput::daemon::asr::RecognitionEventKind::Error:
-      if (!event.error.empty()) {
-        dbus->EmitNotification(vinput::dbus::ClassifyErrorText(event.error));
-      }
-      break;
-    case vinput::daemon::asr::RecognitionEventKind::Completed:
-      break;
-    }
-  }
-}
-
 vinput::daemon::asr::RecognitionRunResult FinishSessionAndCollectResult(
     const std::shared_ptr<vinput::daemon::asr::RecognitionSession>& session,
     std::mutex* session_io_mutex, std::string* error) {
@@ -514,7 +490,6 @@ void DaemonRuntimeController::HandleIncomingAudio(std::span<const int16_t> pcm) 
     }
 
     bool keep_processing = false;
-    bool emit_events = false;
     {
       std::lock_guard<std::mutex> lock(state_mutex_);
       if (active_session_ != session) {
@@ -526,8 +501,7 @@ void DaemonRuntimeController::HandleIncomingAudio(std::span<const int16_t> pcm) 
                                pending_chunk_pcm_.begin() +
                                    static_cast<std::ptrdiff_t>(chunk_to_push.size()));
       ApplyRecognitionEvents(events, &latest_final_text_, &first_partial_logged_,
-                             recording_started_at_, first_non_silent_at_, nullptr);
-      emit_events = !events.empty();
+                             recording_started_at_, first_non_silent_at_, dbus_);
       keep_processing = pending_chunk_pcm_.size() >= kStreamingChunkSamples;
       if (keep_processing) {
         chunk_to_push.assign(pending_chunk_pcm_.begin(),
@@ -538,10 +512,6 @@ void DaemonRuntimeController::HandleIncomingAudio(std::span<const int16_t> pcm) 
       } else {
         chunk_to_push.clear();
       }
-    }
-
-    if (emit_events) {
-      EmitRecognitionEvents(events, dbus_);
     }
 
     if (!keep_processing) {
@@ -867,6 +837,8 @@ void DaemonRuntimeController::WorkerMain() {
         }
         if (!result.text.empty()) {
           order.recognized_text = std::move(result.text);
+          // RecognitionPartial is also the protocol's transcript-update signal.
+          dbus_->EmitRecognitionPartial(order.recognized_text);
         }
         order.pcm.clear();
         order.session.reset();


### PR DESCRIPTION
## Summary

Keep the completed ASR transcript visible while LLM post-processing runs.

- Show the processing state in the preedit and the transcript below it.
- Keep voice status and command/result menus from overwriting each other.
- Ignore stale updates from an earlier frontend session.

## Testing

- Built the Release package successfully.
- Tested locally together with the follow-up keyboard controls.
- Passed formatting, localization, JSON, and diff checks.

## Follow-up

[PR #166](https://github.com/xifan2333/fcitx5-vinput/pull/166) follows this change with Escape/Enter handling during active post-processing.