### PR TITLE
feat: cancel post-processing and use raw dictation

### DIFF
--- a/po/fcitx5-vinput.pot
+++ b/po/fcitx5-vinput.pot
@@ -26,10 +26,13 @@ msgstr ""
 msgid "... Recognizing ..."
 msgstr ""
 
-msgid "... Postprocessing ..."
+msgid "... Postprocessing ... (Esc: Cancel)"
 msgstr ""
 
-msgid "... Applying command ..."
+msgid "... Postprocessing ... (Enter: Use raw ASR text, Esc: Cancel)"
+msgstr ""
+
+msgid "... Applying command ... (Esc: Cancel)"
 msgstr ""
 
 #, c-format

--- a/po/fcitx5-vinput.pot
+++ b/po/fcitx5-vinput.pot
@@ -259,6 +259,9 @@ msgstr ""
 msgid "Recording is not active."
 msgstr ""
 
+msgid "Requested post-processing action is not available."
+msgstr ""
+
 #, c-format
 msgid "Switched scene to '%s'."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -28,8 +28,11 @@ msgstr "... 正在命令 ..."
 msgid "... Recognizing ..."
 msgstr "... 正在识别 ..."
 
-msgid "... Postprocessing ..."
-msgstr "... 正在后处理 ..."
+msgid "... Postprocessing ... (Esc: Cancel)"
+msgstr "... 正在后处理 ...（Esc：取消）"
+
+msgid "... Postprocessing ... (Enter: Use raw ASR text, Esc: Cancel)"
+msgstr "... 正在后处理 ...（Enter：使用原始 ASR 文本，Esc：取消）"
 
 msgid "Voice input daemon is unavailable."
 msgstr "语音输入守护进程不可用。"
@@ -37,8 +40,8 @@ msgstr "语音输入守护进程不可用。"
 msgid "Voice input daemon is not responding."
 msgstr "语音输入守护进程无响应。"
 
-msgid "... Applying command ..."
-msgstr "... 正在应用命令 ..."
+msgid "... Applying command ... (Esc: Cancel)"
+msgstr "... 正在应用命令 ...（Esc：取消）"
 
 #, c-format
 msgid "Command: %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -267,6 +267,9 @@ msgstr "语音输入守护进程暂时不可用。"
 msgid "Command Palette"
 msgstr "命令面板"
 
+msgid "Requested post-processing action is not available."
+msgstr "请求的后处理操作当前不可用。"
+
 #, c-format
 msgid "Search: %s"
 msgstr "搜索: %s"

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -66,6 +66,7 @@ private:
   bool callStartRecording();
   bool callStartCommandRecording(const std::string& selected_text);
   bool callStopRecording(const std::string& scene_id);
+  void callCancelPostprocessing(bool commit_raw_text);
   bool callReloadAsrBackend(std::string* error = nullptr);
   bool callStartAdapter(const std::string& adapter_id, std::string* error = nullptr);
   bool callStopAdapter(const std::string& adapter_id, std::string* error = nullptr);
@@ -164,6 +165,7 @@ private:
   std::chrono::steady_clock::time_point daemon_sync_blocked_until_{};
   std::string last_known_daemon_status_;
   std::optional<std::chrono::steady_clock::time_point> polled_idle_since_;
+  std::optional<fcitx::Key> pending_postprocessing_release_;
   vinput::dbus::AsrBackendState cached_asr_backend_state_;
   bool has_cached_asr_backend_state_ = false;
   std::atomic<uint64_t> asr_state_refresh_seq_{0};

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -42,12 +42,13 @@ std::string InferringPreeditText() {
   return _("... Recognizing ...");
 }
 
-std::string PostprocessingPreeditText() {
-  return _("... Postprocessing ...");
+std::string PostprocessingPreeditText(bool command_mode) {
+  return command_mode ? _("... Postprocessing ... (Esc: Cancel)")
+                      : _("... Postprocessing ... (Enter: Use raw ASR text, Esc: Cancel)");
 }
 
 std::string ApplyingCommandPreeditText() {
-  return _("... Applying command ...");
+  return _("... Applying command ... (Esc: Cancel)");
 }
 
 std::string CommandTranscriptPreeditText(const std::string& text) {
@@ -435,6 +436,16 @@ bool VinputEngine::callStopRecording(const std::string& scene_id) {
   return true;
 }
 
+void VinputEngine::callCancelPostprocessing(bool commit_raw_text) {
+  if (bus_ == nullptr) {
+    return;
+  }
+
+  auto msg = bus_->createMethodCall(kBusName, kObjectPath, kInterface, kMethodCancelPostprocessing);
+  msg << commit_raw_text;
+  msg.send();
+}
+
 void VinputEngine::ensureStatusSync() {
   const bool needs_sync = session_.has_value() || status_ic_ != nullptr;
   if (!needs_sync) {
@@ -777,8 +788,8 @@ void VinputEngine::applyDaemonStatusLocally(const std::string& status,
   }
 
   if (status == kStatusPostprocessing) {
-    enterBusyState(ic, session_ ? session_->command_mode : prefer_command_mode,
-                   PostprocessingPreeditText(), true);
+    const bool command_mode = session_ ? session_->command_mode : prefer_command_mode;
+    enterBusyState(ic, command_mode, PostprocessingPreeditText(command_mode), true);
     return;
   }
 
@@ -887,7 +898,8 @@ void VinputEngine::onRecognitionPartial(fcitx::dbus::Message& msg) {
   rememberInputContext(ic);
   session_->transcript_text = transcript_text;
   if (session_->phase == Session::Phase::Postprocessing) {
-    enterBusyState(ic, session_->command_mode, PostprocessingPreeditText(), true);
+    enterBusyState(ic, session_->command_mode, PostprocessingPreeditText(session_->command_mode),
+                   true);
     return;
   }
 

--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <fcitx-utils/key.h>
+#include <fcitx-utils/keysymgen.h>
 #include <fcitx-utils/utf8.h>
 #include <fcitx/inputcontext.h>
 #include <string>
@@ -43,6 +44,27 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
   auto& keyEvent = static_cast<fcitx::KeyEvent&>(event);
   rememberInputContext(keyEvent.inputContext());
 
+  if (pending_postprocessing_release_ && keyEvent.isRelease() &&
+      keyEvent.key().normalize().sym() == pending_postprocessing_release_->normalize().sym()) {
+    pending_postprocessing_release_.reset();
+    keyEvent.filterAndAccept();
+    return;
+  }
+
+  if (session_ && session_->phase == Session::Phase::Postprocessing &&
+      last_known_daemon_status_ == vinput::dbus::kStatusPostprocessing) {
+    const bool discard = keyEvent.key().check(FcitxKey_Escape);
+    const bool commit_raw = !session_->command_mode && (keyEvent.key().check(FcitxKey_Return) ||
+                                                        keyEvent.key().check(FcitxKey_KP_Enter));
+    if (discard || commit_raw) {
+      if (!keyEvent.isRelease()) {
+        pending_postprocessing_release_ = keyEvent.key();
+        callCancelPostprocessing(commit_raw);
+      }
+      keyEvent.filterAndAccept();
+      return;
+    }
+  }
   const int trigger_index = keyEvent.key().keyListIndex(trigger_keys_);
   const bool is_trigger = trigger_index >= 0;
   const int command_index = keyEvent.key().keyListIndex(command_keys_);

--- a/src/common/dbus/dbus_interface.h
+++ b/src/common/dbus/dbus_interface.h
@@ -17,6 +17,7 @@ constexpr const char* kNotifierInterface = "org.fcitx.Fcitx5.Vinput1";
 constexpr const char* kMethodStartRecording = "StartRecording";
 constexpr const char* kMethodStartCommandRecording = "StartCommandRecording";
 constexpr const char* kMethodStopRecording = "StopRecording";
+constexpr const char* kMethodCancelPostprocessing = "CancelPostprocessing";
 constexpr const char* kMethodGetStatus = "GetStatus";
 constexpr const char* kMethodGetAsrBackendState = "GetAsrBackendState";
 constexpr const char* kMethodReloadAsrBackend = "ReloadAsrBackend";

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -583,6 +583,10 @@ int main(int argc, char* argv[]) {
     return runtime_controller.StopRecording(scene_id);
   });
 
+  dbus.SetCancelPostprocessingHandler([&](bool commit_raw_text) {
+    return runtime_controller.CancelPostprocessing(commit_raw_text);
+  });
+
   dbus.SetStatusHandler([&]() -> std::string { return runtime_controller.GetStatus(); });
   dbus.SetAsrBackendStateHandler(
       [&]() -> vinput::dbus::AsrBackendState { return runtime_controller.GetAsrBackendState(); });

--- a/src/daemon/postprocess/post_processor.cpp
+++ b/src/daemon/postprocess/post_processor.cpp
@@ -14,6 +14,8 @@
 #include <string_view>
 
 #include "common/asr/recognition_result.h"
+#include "common/config/core_config.h"
+#include "common/config/core_config_types.h"
 #include "common/llm/defaults.h"
 #include "common/scene/postprocess_scene.h"
 #include "common/utils/debug_log.h"
@@ -50,8 +52,15 @@ struct CurlGuard {
 };
 
 struct CurlRequestContext {
-  const std::atomic<bool>* cancel_flag = nullptr;
+  const std::atomic<bool>* shutdown_flag = nullptr;
+  const std::atomic<bool>* request_cancel_flag = nullptr;
 };
+
+bool CancellationRequested(const CurlRequestContext& ctx) {
+  return (ctx.shutdown_flag != nullptr && ctx.shutdown_flag->load(std::memory_order_relaxed)) ||
+         (ctx.request_cancel_flag != nullptr &&
+          ctx.request_cancel_flag->load(std::memory_order_relaxed));
+}
 
 size_t WriteResponseCallback(char* ptr, size_t size, size_t nmemb, void* userdata) {
   const size_t total = size * nmemb;
@@ -68,10 +77,7 @@ size_t WriteResponseCallback(char* ptr, size_t size, size_t nmemb, void* userdat
 
 int ProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t) {
   const auto* ctx = static_cast<const CurlRequestContext*>(clientp);
-  if (!ctx || !ctx->cancel_flag) {
-    return 0;
-  }
-  return ctx->cancel_flag->load(std::memory_order_relaxed) ? 1 : 0;
+  return ctx != nullptr && CancellationRequested(*ctx) ? 1 : 0;
 }
 
 std::string_view TrimAsciiWhitespace(std::string_view text) {
@@ -287,8 +293,18 @@ std::optional<std::vector<std::string>>
 RewriteWithOpenAiCompatible(const std::string& text, const vinput::scene::Definition& scene,
                             const LlmProvider& provider, int max_llm_candidates,
                             std::string* error_out, const std::string& task_prompt = {},
-                            const std::atomic<bool>* cancel_flag = nullptr,
+                            const std::atomic<bool>* shutdown_flag = nullptr,
+                            const std::atomic<bool>* request_cancel_flag = nullptr,
                             std::string_view asr_var = {}, std::string_view selected_var = {}) {
+  CurlRequestContext request_context{.shutdown_flag = shutdown_flag,
+                                     .request_cancel_flag = request_cancel_flag};
+  if (CancellationRequested(request_context)) {
+    if (error_out != nullptr) {
+      error_out->clear();
+    }
+    return std::nullopt;
+  }
+
   CurlGuard guard;
   guard.curl = curl_easy_init();
   if (!guard.curl) {
@@ -397,7 +413,6 @@ RewriteWithOpenAiCompatible(const std::string& text, const vinput::scene::Defini
   std::string response_body;
   curl_easy_setopt(guard.curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(guard.curl, CURLOPT_WRITEDATA, &response_body);
-  CurlRequestContext request_context{.cancel_flag = cancel_flag};
   curl_easy_setopt(guard.curl, CURLOPT_NOPROGRESS, 0L);
   curl_easy_setopt(guard.curl, CURLOPT_XFERINFOFUNCTION, ProgressCallback);
   curl_easy_setopt(guard.curl, CURLOPT_XFERINFODATA, &request_context);
@@ -409,11 +424,11 @@ RewriteWithOpenAiCompatible(const std::string& text, const vinput::scene::Defini
   curl_easy_getinfo(guard.curl, CURLINFO_TOTAL_TIME, &total_time_sec);
   const double total_time_ms = total_time_sec * 1000.0;
 
-  const bool cancelled = curl_code == CURLE_ABORTED_BY_CALLBACK && cancel_flag &&
-                         cancel_flag->load(std::memory_order_relaxed);
+  const bool cancelled =
+      curl_code == CURLE_ABORTED_BY_CALLBACK && CancellationRequested(request_context);
 
   if (cancelled) {
-    vinput::debug::Log("LLM request provider=%s url=%s cancelled during shutdown after %.1fms\n",
+    vinput::debug::Log("LLM request provider=%s url=%s cancelled after %.1fms\n",
                        provider.id.empty() ? "(unnamed)" : provider.id.c_str(), url.c_str(),
                        total_time_ms);
     if (error_out) {
@@ -507,8 +522,8 @@ void PostProcessor::Shutdown() {
 
 vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
                                                const vinput::scene::Definition& scene,
-                                               const CoreConfig& settings,
-                                               std::string* error_out) const {
+                                               const CoreConfig& settings, std::string* error_out,
+                                               const std::atomic<bool>* cancel_flag) const {
   std::string normalized = std::string(TrimAsciiWhitespace(raw_text));
   if (normalized.empty()) {
     return {};
@@ -526,7 +541,7 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
   }
 
   auto rewritten = RewriteWithOpenAiCompatible(normalized, scene, *provider, max_llm_candidates,
-                                               error_out, {}, &shutting_down_);
+                                               error_out, {}, &shutting_down_, cancel_flag);
   if (!rewritten.has_value()) {
     return fallback;
   }
@@ -569,7 +584,8 @@ vinput::result::Payload PostProcessor::Process(const std::string& raw_text,
 vinput::result::Payload
 PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& selected_text,
                               const vinput::scene::Definition& command_scene,
-                              const CoreConfig& settings, std::string* error_out) const {
+                              const CoreConfig& settings, std::string* error_out,
+                              const std::atomic<bool>* cancel_flag) const {
   std::string normalized_asr = std::string(TrimAsciiWhitespace(asr_text));
 
   vinput::result::Payload fallback;
@@ -628,9 +644,9 @@ PostProcessor::ProcessCommand(const std::string& asr_text, const std::string& se
   // Data is already embedded in task_prompt (legacy XML tags) or will be
   // substituted via {{asr}}/{{selected}} (interpolation). Pass empty text to
   // avoid double-appending.
-  auto rewritten =
-      RewriteWithOpenAiCompatible("", command_scene, *provider, command_max_llm_candidates,
-                                  error_out, task_prompt, &shutting_down_, asr_var, selected_var);
+  auto rewritten = RewriteWithOpenAiCompatible("", command_scene, *provider,
+                                               command_max_llm_candidates, error_out, task_prompt,
+                                               &shutting_down_, cancel_flag, asr_var, selected_var);
 
   vinput::result::Payload payload;
   std::set<std::string> seen;

--- a/src/daemon/postprocess/post_processor.h
+++ b/src/daemon/postprocess/post_processor.h
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "common/asr/recognition_result.h"
-#include "common/config/core_config.h"
+#include "common/config/core_config_types.h"
 #include "common/scene/postprocess_scene.h"
 
 class PostProcessor {
@@ -16,14 +16,15 @@ public:
 
   vinput::result::Payload Process(const std::string& raw_text,
                                   const vinput::scene::Definition& scene,
-                                  const CoreConfig& settings,
-                                  std::string* error_out = nullptr) const;
+                                  const CoreConfig& settings, std::string* error_out = nullptr,
+                                  const std::atomic<bool>* cancel_flag = nullptr) const;
 
   vinput::result::Payload ProcessCommand(const std::string& asr_text,
                                          const std::string& selected_text,
                                          const vinput::scene::Definition& command_scene,
                                          const CoreConfig& settings,
-                                         std::string* error_out = nullptr) const;
+                                         std::string* error_out = nullptr,
+                                         const std::atomic<bool>* cancel_flag = nullptr) const;
 
 private:
   mutable std::atomic<bool> shutting_down_{false};

--- a/src/daemon/runtime/daemon_runtime_controller.cpp
+++ b/src/daemon/runtime/daemon_runtime_controller.cpp
@@ -1,15 +1,18 @@
 #include "daemon/runtime/daemon_runtime_controller.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <span>
 #include <stdexcept>
 #include <sys/eventfd.h>
 #include <unistd.h>
 #include <utility>
 
+#include "common/asr/recognition_result.h"
 #include "common/config/core_config.h"
 #include "common/dbus/dbus_interface.h"
 #include "common/i18n.h"
@@ -207,6 +210,28 @@ DbusService::MethodResult DaemonRuntimeController::StartRecording() {
 DbusService::MethodResult
 DaemonRuntimeController::StartCommandRecording(const std::string& selected_text) {
   return StartRecordingInternal(true, selected_text);
+}
+
+DbusService::MethodResult DaemonRuntimeController::CancelPostprocessing(bool commit_raw_text) {
+  bool accepted = false;
+  {
+    const std::scoped_lock lock(state_mutex_);
+    accepted = postprocessing_state_ == PostprocessingState::Dictation ||
+               (!commit_raw_text && postprocessing_state_ == PostprocessingState::Command);
+    if (accepted) {
+      postprocessing_state_ =
+          commit_raw_text ? PostprocessingState::CommitRaw : PostprocessingState::Discard;
+      postprocessing_cancel_requested_.store(true, std::memory_order_relaxed);
+    }
+  }
+  if (!accepted) {
+    return DbusService::MethodResult::Failure(
+        _("Requested post-processing action is not available."));
+  }
+
+  vinput::debug::Log("post-processing cancellation requested action=%s\n",
+                     commit_raw_text ? "commit-raw" : "discard");
+  return DbusService::MethodResult::Success();
 }
 
 bool DaemonRuntimeController::SynchronizeAsrBackend(std::string* error) {
@@ -759,19 +784,30 @@ void DaemonRuntimeController::Shutdown() {
   }
 }
 
-void DaemonRuntimeController::SetPhase(vinput::dbus::Status new_phase) {
+void DaemonRuntimeController::EnterPostprocessing(bool command_mode) {
   {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    phase_ = new_phase;
+    const std::scoped_lock lock(state_mutex_);
+    postprocessing_state_ =
+        command_mode ? PostprocessingState::Command : PostprocessingState::Dictation;
+    phase_ = vinput::dbus::Status::Postprocessing;
   }
-  dbus_->EmitStatusChanged(vinput::dbus::StatusToString(new_phase));
+  dbus_->EmitStatusChanged(vinput::dbus::StatusToString(vinput::dbus::Status::Postprocessing));
+}
+
+DaemonRuntimeController::PostprocessingState DaemonRuntimeController::TakePostprocessingState() {
+  const std::scoped_lock lock(state_mutex_);
+  const auto state = postprocessing_state_;
+  postprocessing_state_ = PostprocessingState::Inactive;
+  return state;
 }
 
 void DaemonRuntimeController::ResetToIdle() {
   {
-    std::lock_guard<std::mutex> lock(state_mutex_);
+    const std::scoped_lock lock(state_mutex_);
     start_recording_in_progress_ = false;
     phase_ = vinput::dbus::Status::Idle;
+    postprocessing_state_ = PostprocessingState::Inactive;
+    postprocessing_cancel_requested_.store(false, std::memory_order_relaxed);
     current_order_.reset();
     current_is_command_ = false;
     current_selected_text_.clear();
@@ -844,8 +880,20 @@ void DaemonRuntimeController::WorkerMain() {
         order.session.reset();
       }
 
+      postprocessing_cancel_requested_.store(false, std::memory_order_relaxed);
       auto pipeline_result = pipeline_->Process(
-          order, runtime_settings, [&]() { SetPhase(vinput::dbus::Status::Postprocessing); });
+          order, runtime_settings, [&]() { EnterPostprocessing(order.is_command); },
+          &postprocessing_cancel_requested_);
+      const auto postprocessing_action = TakePostprocessingState();
+      if (postprocessing_action == PostprocessingState::CommitRaw) {
+        pipeline_result.payload.commitText = order.recognized_text;
+        pipeline_result.payload.candidates = {
+            {.text = order.recognized_text, .source = vinput::result::kSourceRaw}};
+        pipeline_result.errors.clear();
+      } else if (postprocessing_action == PostprocessingState::Discard) {
+        pipeline_result.payload = {};
+        pipeline_result.errors.clear();
+      }
       for (const auto& error : pipeline_result.errors) {
         if (!error.raw_message.empty()) {
           fprintf(stderr, "vinput-daemon: processing error: %s\n", error.raw_message.c_str());
@@ -854,9 +902,11 @@ void DaemonRuntimeController::WorkerMain() {
       }
       dbus_->EmitRecognitionResult(vinput::result::Serialize(pipeline_result.payload));
     } catch (const std::exception& e) {
+      (void)TakePostprocessingState();
       fprintf(stderr, "vinput-daemon: worker exception: %s\n", e.what());
       dbus_->EmitNotification(vinput::dbus::MakeRawError(e.what()));
     } catch (...) {
+      (void)TakePostprocessingState();
       fprintf(stderr, "vinput-daemon: worker unknown exception\n");
       dbus_->EmitNotification(vinput::dbus::MakeErrorInfo(
           vinput::dbus::kErrorCodeProcessingUnknown, {}, {}, "Unknown error during processing"));

--- a/src/daemon/runtime/daemon_runtime_controller.h
+++ b/src/daemon/runtime/daemon_runtime_controller.h
@@ -36,6 +36,7 @@ public:
   DbusService::MethodResult StartRecording();
   DbusService::MethodResult StartCommandRecording(const std::string& selected_text);
   DbusService::MethodResult StopRecording(const std::string& scene_id);
+  DbusService::MethodResult CancelPostprocessing(bool commit_raw_text);
   DbusService::MethodResult ReloadAsrBackend();
   std::string GetStatus() const;
   vinput::dbus::AsrBackendState GetAsrBackendState() const;
@@ -46,6 +47,14 @@ public:
   void Shutdown();
 
 private:
+  enum class PostprocessingState : std::uint8_t {
+    Inactive,
+    Dictation,
+    Command,
+    Discard,
+    CommitRaw
+  };
+
   DbusService::MethodResult StartRecordingInternal(bool is_command,
                                                    const std::string& selected_text);
   bool SynchronizeAsrBackend(std::string* error = nullptr);
@@ -54,7 +63,8 @@ private:
   void ScheduleCaptureStopOnMainThread();
   void RestoreOutputIfDucked();
   std::shared_ptr<vinput::daemon::asr::RecognitionSession> ReleaseActiveSessionLocked();
-  void SetPhase(vinput::dbus::Status new_phase);
+  void EnterPostprocessing(bool command_mode);
+  PostprocessingState TakePostprocessingState();
   void ResetToIdle();
   void WorkerMain();
 
@@ -69,6 +79,8 @@ private:
   mutable std::mutex session_io_mutex_;
   std::condition_variable worker_cv_;
   vinput::dbus::Status phase_ = vinput::dbus::Status::Idle;
+  PostprocessingState postprocessing_state_ = PostprocessingState::Inactive;
+  std::atomic<bool> postprocessing_cancel_requested_{false};
   std::optional<RecognitionOrder> current_order_;
   std::shared_ptr<vinput::daemon::asr::RecognitionSession> active_session_;
   vinput::daemon::asr::BackendDescriptor active_backend_;

--- a/src/daemon/runtime/dbus_service.cpp
+++ b/src/daemon/runtime/dbus_service.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <utility>
 
 #include "common/dbus/dbus_interface.h"
 
@@ -46,6 +47,8 @@ static const sd_bus_vtable vtable[] = {
     SD_BUS_METHOD(kMethodStartCommandRecording, "s", "", &DbusService::handleStartCommandRecording,
                   SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD(kMethodStopRecording, "s", "s", &DbusService::handleStopRecording,
+                  SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD(kMethodCancelPostprocessing, "b", "", &DbusService::handleCancelPostprocessing,
                   SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD(kMethodGetStatus, "", "s", &DbusService::handleGetStatus,
                   SD_BUS_VTABLE_UNPRIVILEGED),
@@ -197,6 +200,11 @@ void DbusService::SetStopHandler(std::function<MethodResult(const std::string& s
   stop_handler_ = std::move(handler);
 }
 
+void DbusService::SetCancelPostprocessingHandler(
+    std::function<MethodResult(bool commit_raw_text)> handler) {
+  cancel_postprocessing_handler_ = std::move(handler);
+}
+
 void DbusService::SetStatusHandler(std::function<std::string()> handler) {
   status_handler_ = std::move(handler);
 }
@@ -258,6 +266,23 @@ int DbusService::handleStopRecording(sd_bus_message* m, void* userdata, sd_bus_e
     result = self->stop_handler_(scene_id ? scene_id : "");
   }
   return ReplyWithMethodResult(m, error, result, "s");
+}
+
+int DbusService::handleCancelPostprocessing(sd_bus_message* m, void* userdata,
+                                            sd_bus_error* error) {
+  auto* self = static_cast<DbusService*>(userdata);
+  int commit_raw_text = 0;
+  const int ret = sd_bus_message_read(m, "b", &commit_raw_text);
+  if (ret < 0) {
+    fprintf(stderr, "vinput: failed to read CancelPostprocessing action: %s\n", strerror(-ret));
+    return ret;
+  }
+
+  MethodResult result;
+  if (self->cancel_postprocessing_handler_) {
+    result = self->cancel_postprocessing_handler_(commit_raw_text != 0);
+  }
+  return ReplyWithMethodResult(m, error, result, "");
 }
 
 int DbusService::handleGetStatus(sd_bus_message* m, void* userdata, sd_bus_error* error) {

--- a/src/daemon/runtime/dbus_service.h
+++ b/src/daemon/runtime/dbus_service.h
@@ -47,6 +47,7 @@ public:
   void SetStartHandler(std::function<MethodResult()> handler);
   void SetStartCommandHandler(std::function<MethodResult(const std::string&)> handler);
   void SetStopHandler(std::function<MethodResult(const std::string& scene_id)> handler);
+  void SetCancelPostprocessingHandler(std::function<MethodResult(bool commit_raw_text)> handler);
   void SetStatusHandler(std::function<std::string()> handler);
   void SetAsrBackendStateHandler(std::function<vinput::dbus::AsrBackendState()> handler);
   void SetReloadAsrBackendHandler(std::function<MethodResult()> handler);
@@ -56,6 +57,7 @@ public:
   static int handleStartRecording(sd_bus_message* m, void* userdata, sd_bus_error* error);
   static int handleStartCommandRecording(sd_bus_message* m, void* userdata, sd_bus_error* error);
   static int handleStopRecording(sd_bus_message* m, void* userdata, sd_bus_error* error);
+  static int handleCancelPostprocessing(sd_bus_message* m, void* userdata, sd_bus_error* error);
   static int handleGetStatus(sd_bus_message* m, void* userdata, sd_bus_error* error);
   static int handleGetAsrBackendState(sd_bus_message* m, void* userdata, sd_bus_error* error);
   static int handleReloadAsrBackend(sd_bus_message* m, void* userdata, sd_bus_error* error);
@@ -79,6 +81,7 @@ private:
   std::function<MethodResult()> start_handler_;
   std::function<MethodResult(const std::string&)> start_command_handler_;
   std::function<MethodResult(const std::string& scene_id)> stop_handler_;
+  std::function<MethodResult(bool commit_raw_text)> cancel_postprocessing_handler_;
   std::function<std::string()> status_handler_;
   std::function<vinput::dbus::AsrBackendState()> asr_backend_state_handler_;
   std::function<MethodResult()> reload_asr_backend_handler_;

--- a/src/daemon/runtime/recognition_pipeline.cpp
+++ b/src/daemon/runtime/recognition_pipeline.cpp
@@ -1,5 +1,10 @@
 #include "daemon/runtime/recognition_pipeline.h"
 
+#include <atomic>
+#include <functional>
+
+#include "common/config/core_config.h"
+#include "common/config/core_config_types.h"
 #include "common/dbus/error_info.h"
 #include "common/utils/debug_log.h"
 
@@ -31,7 +36,8 @@ RecognitionPipeline::RecognitionPipeline(PostProcessor* post_processor)
 
 RecognitionPipelineResult
 RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& settings,
-                             const std::function<void()>& on_enter_postprocessing) const {
+                             const std::function<void()>& on_enter_postprocessing,
+                             const std::atomic<bool>* cancel_flag) const {
   RecognitionPipelineResult output;
   if (!post_processor_) {
     output.errors.push_back(vinput::dbus::MakeRawError("Recognition pipeline is not initialized."));
@@ -62,8 +68,9 @@ RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& se
     fallback_cmd.builtin = true;
     const auto& command_scene = cmd_scene ? *cmd_scene : fallback_cmd;
     std::string llm_error;
-    output.payload = post_processor_->ProcessCommand(order.recognized_text, order.selected_text,
-                                                     command_scene, settings, &llm_error);
+    output.payload =
+        post_processor_->ProcessCommand(order.recognized_text, order.selected_text, command_scene,
+                                        settings, &llm_error, cancel_flag);
     if (!llm_error.empty()) {
       output.errors.push_back(vinput::dbus::ClassifyErrorText(llm_error));
     }
@@ -76,7 +83,8 @@ RecognitionPipeline::Process(const RecognitionOrder& order, const CoreConfig& se
   }
 
   std::string llm_error;
-  output.payload = post_processor_->Process(order.recognized_text, scene, settings, &llm_error);
+  output.payload =
+      post_processor_->Process(order.recognized_text, scene, settings, &llm_error, cancel_flag);
   if (!llm_error.empty()) {
     output.errors.push_back(vinput::dbus::ClassifyErrorText(llm_error));
   }

--- a/src/daemon/runtime/recognition_pipeline.h
+++ b/src/daemon/runtime/recognition_pipeline.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "common/asr/recognition_result.h"
-#include "common/config/core_config.h"
+#include "common/config/core_config_types.h"
 #include "common/dbus/error_info.h"
 
 #include "daemon/asr/runtime/recognition_contract.h"
@@ -35,9 +36,9 @@ class RecognitionPipeline {
 public:
   explicit RecognitionPipeline(PostProcessor* post_processor);
 
-  RecognitionPipelineResult
-  Process(const RecognitionOrder& order, const CoreConfig& settings,
-          const std::function<void()>& on_enter_postprocessing = {}) const;
+  RecognitionPipelineResult Process(const RecognitionOrder& order, const CoreConfig& settings,
+                                    const std::function<void()>& on_enter_postprocessing = {},
+                                    const std::atomic<bool>* cancel_flag = nullptr) const;
 
 private:
   PostProcessor* post_processor_ = nullptr;


### PR DESCRIPTION
## Summary

Add keyboard controls while LLM post-processing is active.

- Escape cancels and discards the pending result.
- Enter or keypad Enter commits the raw ASR text during dictation.
- Command mode accepts Escape only.
- The preedit labels the available actions in English and Chinese.

## Testing

- Built the Release package successfully.
- Tested dictation and command-mode behavior locally.
- Passed formatting, localization, JSON, and diff checks.