### PR TITLE
refactor(gui): clarify candidate count as LLM max results (#167)

### DIFF
--- a/i18n/vinput-gui_zh_CN.ts
+++ b/i18n/vinput-gui_zh_CN.ts
@@ -3,52 +3,52 @@
 <context>
     <name>AdapterDialog</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="57" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="57" />
         <source>Configure LLM Adapter</source>
         <translation>配置 LLM 适配器</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="68" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="68" />
         <source>One argument per line</source>
         <translation>每行一个参数</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="69" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="69" />
         <source>One KEY=VALUE entry per line</source>
         <translation>每行一个 KEY=VALUE 条目</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="70" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="70" />
         <source>Command or interpreter</source>
         <translation>命令或解释器</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="76" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="76" />
         <source>Adapter ID:</source>
         <translation>适配器 ID：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="77" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="77" />
         <source>Command / Interpreter:</source>
         <translation>命令 / 解释器：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="78" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="78" />
         <source>Args:</source>
         <translation>参数：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="79" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="79" />
         <source>Env:</source>
         <translation>环境变量：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="81" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="81" />
         <source>Start with daemon</source>
         <translation>随守护进程启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/adapter_dialog.cpp" line="105" />
+        <location filename="../src/gui/dialogs/adapter_dialog.cpp" line="105" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
@@ -56,74 +56,74 @@
 <context>
     <name>AsrProviderDialog</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="109" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="109" />
         <source>local</source>
         <translation>本地</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="111" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="111" />
         <source>command</source>
         <translation>命令</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="114" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="114" />
         <source>One argument per line</source>
         <translation>每行一个参数</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="115" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="115" />
         <source>One KEY=VALUE entry per line</source>
         <translation>每行一个 KEY=VALUE 条目</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="166" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="166" />
         <source>Name:</source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="167" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="167" />
         <source>Type:</source>
         <translation>类型：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="168" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="168" />
         <source>Model:</source>
         <translation>模型：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="169" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="169" />
         <source>Command / Interpreter:</source>
         <translation>命令 / 解释器：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="170" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="170" />
         <source>Args:</source>
         <translation>参数：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="171" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="171" />
         <source>Env:</source>
         <translation>环境变量：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="172" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="172" />
         <source>Timeout (ms):</source>
         <translation>超时（毫秒）：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="189" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="209" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="221" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="189" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="209" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="221" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="190" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="190" />
         <source>Provider name must not be empty.</source>
         <translation>提供程序名称不能为空。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/dialogs/asr_provider_dialog.cpp" line="210" />
+        <location filename="../src/gui/dialogs/asr_provider_dialog.cpp" line="210" />
         <source>Command providers require a command.</source>
         <translation>命令类型的提供程序需要填写命令。</translation>
     </message>
@@ -131,37 +131,37 @@
 <context>
     <name>GuiHelpers</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="53" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="53" />
         <source>Provider name must not be empty.</source>
         <translation>提供程序名称不能为空。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="62" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="62" />
         <source>Base URL must be a valid http:// or https:// URL.</source>
         <translation>Base URL 必须是有效的 http:// 或 https:// 地址。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="81" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="81" />
         <source>Invalid env entry '%1'. Use KEY=VALUE.</source>
         <translation>无效的环境变量条目“%1”，请使用 KEY=VALUE 格式。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="112" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="112" />
         <source>No models returned. You can type one manually.</source>
         <translation>未返回任何模型，可手动输入。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="130" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="130" />
         <source>Failed to load models. Type one manually or reselect the provider to retry.</source>
         <translation>模型加载失败，可手动输入或重新选择提供程序重试。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="168" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="168" />
         <source>Loading models...</source>
         <translation>正在加载模型…</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/utils/gui_helpers.cpp" line="212" />
+        <location filename="../src/gui/utils/gui_helpers.cpp" line="212" />
         <source>Provider returned invalid JSON for /v1/models.</source>
         <translation>提供程序的 /v1/models 返回了无效的 JSON。</translation>
     </message>
@@ -169,63 +169,63 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="33" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="33" />
         <source>Vinput Configuration</source>
         <translation>Vinput 配置</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="52" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="52" />
         <source>Control</source>
         <translation>控制</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="53" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="53" />
         <source>Resources</source>
         <translation>资源</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="54" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="54" />
         <source>LLM</source>
         <translation>LLM</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="56" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="56" />
         <source>Hotwords</source>
         <translation>热词</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="66" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="66" />
         <source>Open Config</source>
         <translation>打开配置</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="69" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="69" />
         <source>Save Settings</source>
         <translation>保存设置</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="132" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="139" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="132" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="139" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="132" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="132" />
         <source>Failed to save config.</source>
         <translation>保存配置失败。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="142" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="142" />
         <source>Success</source>
         <translation>成功</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="142" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="142" />
         <source>Settings saved successfully!</source>
         <translation>设置已成功保存！</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/app/mainwindow.cpp" line="264" />
+        <location filename="../src/gui/app/mainwindow.cpp" line="264" />
         <source>Details</source>
         <translation>查看详情</translation>
     </message>
@@ -233,254 +233,254 @@
 <context>
     <name>vinput::gui::ControlPage</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="122" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="257" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="122" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="257" />
         <source>Start</source>
         <translation>启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="123" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="258" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="123" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="258" />
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="124" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="124" />
         <source>Start with daemon</source>
         <translation>随守护进程启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="131" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="131" />
         <source>&lt;b&gt;Audio&lt;/b&gt;</source>
         <translation>&lt;b&gt;音频&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="136" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="136" />
         <source>Capture Device:</source>
         <translation>录音设备：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="138" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="138" />
         <source>Normalize audio</source>
         <translation>归一化音频</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="140" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="140" />
         <source>Apply peak normalization to captured audio before recognition.</source>
         <translation>在识别前对采集到的音频做峰值归一化。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="147" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="147" />
         <source>Microphone gain multiplier applied to captured audio.</source>
         <translation>应用于采集音频的麦克风增益倍数。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="148" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="148" />
         <source>Input gain:</source>
         <translation>输入增益：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="151" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="151" />
         <source>Trim silence (VAD)</source>
         <translation>裁剪静音（VAD）</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="152" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="152" />
         <source>Use voice activity detection to trim leading/trailing silence.</source>
         <translation>使用语音活动检测裁剪首尾静音。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="156" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="156" />
         <source>Reduce output volume while recording</source>
         <translation>录音时降低输出音量</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="157" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="157" />
         <source>Lower the system output volume while recording, then restore it. Useful when speaker sound leaks into the microphone.</source>
         <translation>录音时降低系统输出音量，结束后恢复。适用于外放声音被麦克风收入、干扰识别的情况。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="163" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="163" />
         <source> %</source>
         <translation> %</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="164" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="164" />
         <source>Fraction of the current output volume to keep while recording.</source>
         <translation>录音时保留的当前输出音量比例。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="165" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="165" />
         <source>Output volume while recording:</source>
         <translation>录音时的输出音量：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="180" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="180" />
         <source>&lt;b&gt;ASR Providers&lt;/b&gt;</source>
         <translation>&lt;b&gt;ASR 提供商&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="188" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="188" />
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="189" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="189" />
         <source>Activate</source>
         <translation>激活</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="213" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="213" />
         <source>&lt;b&gt;LLM Adapters&lt;/b&gt;</source>
         <translation>&lt;b&gt;LLM 适配器&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="221" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="221" />
         <source>Automatically start this adapter when vinput-daemon starts.</source>
         <translation>当 vinput-daemon 启动时自动启动此适配器。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="247" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="247" />
         <source>Daemon Status:</source>
         <translation>守护进程状态：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="248" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="248" />
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="259" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="259" />
         <source>Restart</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="394" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="394" />
         <source>(not set)</source>
         <translation>（未设置）</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="401" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="401" />
         <source>configured</source>
         <translation>已配置</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="404" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="404" />
         <source>effective</source>
         <translation>已生效</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="407" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="407" />
         <source>loading</source>
         <translation>加载中</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="410" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="410" />
         <source>reload failed</source>
         <translation>重载失败</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="476" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="476" />
         <source>Edit ASR Provider</source>
         <translation>编辑 ASR 提供商</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="506" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="530" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="635" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="656" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="684" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="737" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="774" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="506" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="530" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="635" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="656" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="684" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="737" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="774" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="506" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="530" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="684" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="506" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="530" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="684" />
         <source>Failed to save config.</source>
         <translation>保存配置失败。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="513" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="537" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="513" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="537" />
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="514" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="538" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="514" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="538" />
         <source>Config saved, but failed to reload ASR backend: %1</source>
         <translation>配置已保存，但重新加载 ASR 后端失败：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="560" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="560" />
         <source>running</source>
         <translation>运行中</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="560" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="560" />
         <source>stopped</source>
         <translation>已停止</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="561" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="561" />
         <source>autostart</source>
         <translation>自启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="561" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="561" />
         <source>manual</source>
         <translation>手动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="575" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="575" />
         <source>Command: %1</source>
         <translation>命令：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="582" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="582" />
         <source>Args: %1</source>
         <translation>参数：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="589" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="589" />
         <source>Env: %1</source>
         <translation>环境变量：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="696" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="696" />
         <source>Stopped</source>
         <translation>已停止</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="704" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="704" />
         <source>Running (Status Error: %1)</source>
         <translation>运行中（状态错误：%1）</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="711" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="711" />
         <source>Running: %1 (loading backend)</source>
         <translation>运行中：%1（后端加载中）</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="714" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="714" />
         <source>Running: %1 (backend error)</source>
         <translation>运行中：%1（后端错误）</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="716" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="716" />
         <source>Running: %1</source>
         <translation>运行中：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="794" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="794" />
         <source>Additional Install Required</source>
         <translation>需要额外配置</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/control/control_page.cpp" line="795" />
+        <location filename="../src/gui/pages/control/control_page.cpp" line="795" />
         <source>Vinput requires additional Flatpak permissions. Run the following commands, then restart Fcitx5:
 
 %1</source>
@@ -492,27 +492,27 @@
 <context>
     <name>vinput::gui::HotwordPage</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="22" />
+        <location filename="../src/gui/pages/hotwords/hotword_page.cpp" line="22" />
         <source>Path to hotwords file...</source>
         <translation>热词文件路径...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="23" />
+        <location filename="../src/gui/pages/hotwords/hotword_page.cpp" line="23" />
         <source>Browse...</source>
         <translation>浏览...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="29" />
+        <location filename="../src/gui/pages/hotwords/hotword_page.cpp" line="29" />
         <source>Hotwords (one per line, optional transducer score: "word:2.0"):</source>
         <translation>热词（每行一个，可选 Transducer 权重："词:2.0"）：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="80" />
+        <location filename="../src/gui/pages/hotwords/hotword_page.cpp" line="80" />
         <source>Select Hotwords File</source>
         <translation>选择热词文件</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/hotwords/hotword_page.cpp" line="81" />
+        <location filename="../src/gui/pages/hotwords/hotword_page.cpp" line="81" />
         <source>Text Files (*.txt);;All Files (*)</source>
         <translation>文本文件 (*.txt);;所有文件 (*)</translation>
     </message>
@@ -520,378 +520,384 @@
 <context>
     <name>vinput::gui::LlmPage</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="81" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="89" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="337" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="348" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="360" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="412" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="432" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="467" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="492" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="498" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="593" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="605" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="654" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="695" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="717" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="802" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="807" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="891" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="896" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="922" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="927" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="946" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="952" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="81" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="89" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="337" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="348" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="360" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="412" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="432" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="467" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="492" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="498" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="593" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="605" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="654" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="695" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="717" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="802" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="807" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="891" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="896" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="922" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="927" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="946" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="952" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="82" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="82" />
         <source>Extra body must be a JSON object (e.g. {"enable_thinking": false}).</source>
         <translation>附加请求体必须是 JSON 对象（例如 {"enable_thinking": false}）。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="90" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="90" />
         <source>Invalid extra_body JSON: %1</source>
         <translation>extra_body JSON 无效：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="97" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="97" />
         <source>Optional JSON object merged into each request body, e.g. {"enable_thinking": false}</source>
         <translation>可选的 JSON 对象，将合并进每次请求体，例如 {"enable_thinking": false}</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="113" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="113" />
         <source>Raw</source>
         <translation>原始</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="116" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="116" />
         <source>Command</source>
         <translation>命令</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="162" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="162" />
         <source>&lt;b&gt;Providers&lt;/b&gt;</source>
         <translation>&lt;b&gt;提供商&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="168" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="208" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="168" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="208" />
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="169" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="185" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="209" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="169" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="185" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="209" />
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="170" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="186" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="210" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="170" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="186" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="210" />
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="171" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="530" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="171" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="530" />
         <source>Test</source>
         <translation>测试</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="187" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="187" />
         <source>Start</source>
         <translation>启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="188" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="188" />
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="189" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="189" />
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="198" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="198" />
         <source>&lt;b&gt;LLM Adapters&lt;/b&gt;</source>
         <translation>&lt;b&gt;LLM 适配器&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="202" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="202" />
         <source>&lt;b&gt;Scenes&lt;/b&gt;</source>
         <translation>&lt;b&gt;场景&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="211" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="211" />
         <source>Activate</source>
         <translation>激活</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="270" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="270" />
         <source>running</source>
         <translation>运行中</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="270" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="270" />
         <source>stopped</source>
         <translation>已停止</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="271" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="271" />
         <source>autostart</source>
         <translation>自启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="271" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="271" />
         <source>manual</source>
         <translation>手动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="285" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="285" />
         <source>Autostart: %1</source>
         <translation>自启动：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="285" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="285" />
         <source>enabled</source>
         <translation>已启用</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="285" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="285" />
         <source>disabled</source>
         <translation>已禁用</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="287" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="287" />
         <source>Command: %1</source>
         <translation>命令：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="293" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="293" />
         <source>Args: %1</source>
         <translation>参数：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="299" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="299" />
         <source>Env: %1</source>
         <translation>环境变量：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="308" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="308" />
         <source>Add LLM Provider</source>
         <translation>添加 LLM 提供商</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="317" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="393" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="317" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="393" />
         <source>Name:</source>
         <translation>名称：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="318" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="394" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="318" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="394" />
         <source>Base URL:</source>
         <translation>地址：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="319" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="395" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="319" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="395" />
         <source>API Key:</source>
         <translation>密钥：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="320" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="396" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="320" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="396" />
         <source>Extra body (JSON):</source>
         <translation>附加请求体 (JSON)：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="348" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="348" />
         <source>LLM provider '%1' already exists.</source>
         <translation>LLM 提供者 '%1' 已存在。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="360" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="432" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="467" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="605" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="654" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="807" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="896" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="927" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="952" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="360" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="432" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="467" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="605" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="654" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="807" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="896" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="927" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="952" />
         <source>Failed to save config.</source>
         <translation>保存配置失败。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="382" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="382" />
         <source>Edit LLM Provider</source>
         <translation>编辑 LLM 提供商</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="390" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="390" />
         <source>Leave empty to keep current key</source>
         <translation>留空保持当前密钥不变</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="448" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="626" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="916" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="448" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="626" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="916" />
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="449" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="449" />
         <source>Are you sure you want to remove LLM provider '%1'?</source>
         <translation>确定要移除 LLM 提供商"%1"吗？</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="476" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="476" />
         <source>Scenes Updated</source>
         <translation>场景已更新</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="477" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="477" />
         <source>Removed provider '%1' and cleared it from %2 scene(s).</source>
         <translation>已移除提供商"%1"，并从 %2 个场景中清除了它的引用。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="492" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="492" />
         <source>Provider '%1' not found.</source>
         <translation>未找到提供商"%1"。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="498" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="498" />
         <source>Provider base_url is empty.</source>
         <translation>提供商 base_url 为空。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="506" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="506" />
         <source>Testing...</source>
         <translation>测试中...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="534" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="541" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="534" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="541" />
         <source>Test Failed</source>
         <translation>测试失败</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="535" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="535" />
         <source>Connection to '%1' failed:
 %2</source>
         <translation>连接"%1"失败：
 %2</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="542" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="542" />
         <source>Invalid response from '%1'.</source>
         <translation>"%1"返回了无效的响应。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="559" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="559" />
         <source>Connected to '%1'.
 Found %2 model(s).</source>
         <translation>已连接"%1"。
 找到 %2 个模型。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="563" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="563" />
         <source>Test Succeeded</source>
         <translation>测试成功</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="594" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="594" />
         <source>Adapter '%1' not found in configuration.</source>
         <translation>配置中未找到适配器"%1"。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="627" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="627" />
         <source>Are you sure you want to remove LLM adapter '%1'?</source>
         <translation>确定要移除 LLM 适配器“%1”吗？</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="698" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="698" />
         <source>LLM Adapter Started</source>
         <translation>LLM 适配器已启动</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="699" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="699" />
         <source>Adapter '%1' started.</source>
         <translation>适配器"%1"已启动。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="740" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="740" />
         <source>Add Scene</source>
         <translation>添加场景</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="761" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="851" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="758" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="849" />
+        <source>Maximum number of LLM rewrite results (0 to disable LLM).</source>
+        <translation>LLM 改写结果的最大数量（0 表示不使用 LLM）。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="762" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="853" />
         <source>Include raw transcript in candidate options</source>
         <translation>在候选词选项中包含原始语音文本</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="766" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="857" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="767" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="859" />
         <source>ID:</source>
         <translation>ID：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="767" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="858" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="768" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="860" />
         <source>Label:</source>
         <translation>标签：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="768" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="859" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="769" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="861" />
         <source>Prompt:</source>
         <translation>提示词：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="769" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="860" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="770" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="862" />
         <source>Provider:</source>
         <translation>提供者：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="770" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="861" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="771" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="863" />
         <source>Model:</source>
         <translation>模型：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="771" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="862" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="772" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="864" />
         <source>Context Lines:</source>
         <translation>上下文行数：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="772" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="863" />
-        <source>Candidate Count:</source>
-        <translation>候选数量：</translation>
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="773" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="865" />
+        <source>LLM Max Results:</source>
+        <translation>LLM 最大结果数：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="773" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="864" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="774" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="866" />
         <source>Timeout (ms):</source>
         <translation>超时（毫秒）：</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="828" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="829" />
         <source>Edit Scene</source>
         <translation>编辑场景</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/llm/llm_page.cpp" line="916" />
+        <location filename="../src/gui/pages/llm/llm_page.cpp" line="918" />
         <source>Are you sure you want to remove scene '%1'?</source>
         <translation>确定要移除场景"%1"吗？</translation>
     </message>
@@ -899,334 +905,334 @@ Found %2 model(s).</source>
 <context>
     <name>vinput::gui::ResourcePage</name>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="94" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="94" />
         <source>&lt;b&gt;Installed Models&lt;/b&gt;</source>
         <translation>&lt;b&gt;已安装模型&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="96" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="96" />
         <source>Filter installed models...</source>
         <translation>筛选已安装模型...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="102" />
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="123" />
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="123" />
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="124" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="124" />
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="124" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="124" />
         <source>Hotwords</source>
         <translation>热词</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="102" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="124" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="180" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="102" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="124" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="180" />
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="106" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="106" />
         <source>Use</source>
         <translation>使用</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="107" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="159" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="184" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="107" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="159" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="184" />
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="108" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="142" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="108" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="142" />
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="116" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="116" />
         <source>&lt;b&gt;Available Models&lt;/b&gt;</source>
         <translation>&lt;b&gt;可用模型&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="118" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="118" />
         <source>Filter available models...</source>
         <translation>筛选可用模型...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="180" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="123" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="180" />
         <source>Title</source>
         <translation>标题</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="123" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="180" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="123" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="180" />
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="127" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="127" />
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="133" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="133" />
         <source>Models</source>
         <translation>模型</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="147" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="147" />
         <source>&lt;b&gt;Available ASR Providers&lt;/b&gt;</source>
         <translation>&lt;b&gt;可用 ASR 提供商&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="150" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="150" />
         <source>Filter available ASR providers...</source>
         <translation>筛选可用 ASR 提供商...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="155" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="155" />
         <source>Mode</source>
         <translation>模式</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="158" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="183" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="158" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="183" />
         <source>Install</source>
         <translation>安装</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="169" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="169" />
         <source>ASR Providers</source>
         <translation>ASR 提供商</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="173" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="173" />
         <source>&lt;b&gt;Available LLM Adapters&lt;/b&gt;</source>
         <translation>&lt;b&gt;可用 LLM 适配器&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="175" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="175" />
         <source>Filter available LLM adapters...</source>
         <translation>筛选可用 LLM 适配器...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="191" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="191" />
         <source>LLM Adapters</source>
         <translation>LLM 适配器</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="280" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="280" />
         <source>I18n cache reload error: %1</source>
         <translation>i18n 缓存重载错误：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="285" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="285" />
         <source>Registry fetch completed.</source>
         <translation>注册表获取完成。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="345" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="403" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="345" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="403" />
         <source>yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="345" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="403" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="345" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="403" />
         <source>no</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="349" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="349" />
         <source>active</source>
         <translation>激活</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="351" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="351" />
         <source>broken</source>
         <translation>损坏</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="353" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="407" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="446" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="477" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="353" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="407" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="446" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="477" />
         <source>installed</source>
         <translation>已安装</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="407" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="446" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="477" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="407" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="446" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="477" />
         <source>available</source>
         <translation>可下载</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="443" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="443" />
         <source>stream</source>
         <translation>流式</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="443" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="443" />
         <source>non-stream</source>
         <translation>非流式</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="502" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="502" />
         <source>Fetching remote registry...</source>
         <translation>正在获取远程注册表...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="547" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="547" />
         <source>Models fetch error: %1</source>
         <translation>获取模型出错：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="551" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="551" />
         <source>Providers fetch error: %1</source>
         <translation>获取提供者出错：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="555" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="555" />
         <source>Adapters fetch error: %1</source>
         <translation>获取适配器出错：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="560" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="560" />
         <source>Registry warning: %1</source>
         <translation>注册表警告：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="611" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="615" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="659" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="667" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="677" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="942" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="959" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="1019" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="611" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="615" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="659" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="667" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="677" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="942" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="959" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="1019" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="615" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="667" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="959" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="1019" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="615" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="667" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="959" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="1019" />
         <source>Failed to save config.</source>
         <translation>保存配置失败。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="622" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="968" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="622" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="968" />
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="623" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="678" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="969" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="623" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="678" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="969" />
         <source>Config saved, but failed to reload ASR backend: %1</source>
         <translation>配置已保存，但重新加载 ASR 后端失败：%1</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="627" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="627" />
         <source>Selected model '%1' saved as the preferred local ASR model. Backend reload is in progress.</source>
         <translation>已将所选模型"%1"保存为首选本地 ASR 模型。后端正在重新加载。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="652" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="929" />
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="992" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="652" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="929" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="992" />
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="652" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="652" />
         <source>Are you sure you want to remove model '%1'?</source>
         <translation>确定要移除模型"%1"吗？</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="671" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="671" />
         <source>Removed %1.</source>
         <translation>已移除 %1。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="688" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="688" />
         <source>Downloading... %1% at %2</source>
         <translation>正在下载... %1% 速度 %2</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="695" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="695" />
         <source>Download Error</source>
         <translation>下载错误</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="740" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="740" />
         <source>Preparing download...</source>
         <translation>正在准备下载...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="769" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="769" />
         <source>Starting download for %1...</source>
         <translation>开始下载 %1...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="820" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="820" />
         <source>Installing provider %1...</source>
         <translation>正在安装提供者 %1...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="869" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="869" />
         <source>Installing adapter %1...</source>
         <translation>正在安装适配器 %1...</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="929" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="929" />
         <source>Are you sure you want to remove ASR provider '%1'?</source>
         <translation>确定要移除 ASR 提供商“%1”吗？</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="942" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="942" />
         <source>The local ASR provider cannot be removed.</source>
         <translation>本地 ASR 提供商不能被移除。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="962" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="962" />
         <source>Removed ASR provider %1.</source>
         <translation>已移除 ASR 提供商 %1。</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="992" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="992" />
         <source>Are you sure you want to remove LLM adapter '%1'?</source>
         <translation>确定要移除 LLM 适配器“%1”吗？</translation>
     </message>
     <message>
-        <location filename="../home/xifan/Code/fcitx5-vinput/src/gui/pages/resources/resource_page.cpp" line="1022" />
+        <location filename="../src/gui/pages/resources/resource_page.cpp" line="1022" />
         <source>Removed LLM adapter %1.</source>
         <translation>已移除 LLM 适配器 %1。</translation>
     </message>

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -755,6 +755,7 @@ void LlmPage::onSceneAdd() {
   spinLlmMaxCandidates->setRange(vinput::scene::kMinLlmMaxCandidates,
                                  vinput::scene::kMaxLlmMaxCandidates);
   spinLlmMaxCandidates->setValue(kDefaultUiLlmMaxCandidates);
+  spinLlmMaxCandidates->setToolTip(tr("Maximum number of LLM rewrite results (0 to disable LLM)."));
   auto* spinContextLines = new QSpinBox();
   spinContextLines->setRange(0, 9999);
   spinContextLines->setValue(vinput::scene::kDefaultContextLines);
@@ -769,7 +770,7 @@ void LlmPage::onSceneAdd() {
   form->addRow(tr("Provider:"), comboProvider);
   form->addRow(tr("Model:"), comboModel);
   form->addRow(tr("Context Lines:"), spinContextLines);
-  form->addRow(tr("Candidate Count:"), spinLlmMaxCandidates);
+  form->addRow(tr("LLM Max Results:"), spinLlmMaxCandidates);
   form->addRow(tr("Timeout (ms):"), spinTimeout);
   form->addRow(QString(), chkShowRaw);
 
@@ -845,6 +846,7 @@ void LlmPage::onSceneEdit() {
   spinLlmMaxCandidates->setRange(vinput::scene::kMinLlmMaxCandidates,
                                  vinput::scene::kMaxLlmMaxCandidates);
   spinLlmMaxCandidates->setValue(found->llm_max_candidates);
+  spinLlmMaxCandidates->setToolTip(tr("Maximum number of LLM rewrite results (0 to disable LLM)."));
   auto* spinContextLines = new QSpinBox();
   spinContextLines->setRange(0, 9999);
   spinContextLines->setValue(found->context_lines);
@@ -860,7 +862,7 @@ void LlmPage::onSceneEdit() {
   form->addRow(tr("Provider:"), comboProvider);
   form->addRow(tr("Model:"), comboModel);
   form->addRow(tr("Context Lines:"), spinContextLines);
-  form->addRow(tr("Candidate Count:"), spinLlmMaxCandidates);
+  form->addRow(tr("LLM Max Results:"), spinLlmMaxCandidates);
   form->addRow(tr("Timeout (ms):"), spinTimeout);
   form->addRow(QString(), chkShowRaw);
 


### PR DESCRIPTION
Closes #167

### Implementation Tasks
- [x] 1. Clarify candidate count label to 'LLM Max Results:' with tooltip in src/gui and sync i18n/vinput-gui_zh_CN.ts

### Validation
- Local lightweight quality gates (clang-format, hk, check-i18n.py) passed: po 0 missing/obsolete/untranslated; ts 0 missing/vanished/untranslated.
- lrelease6 compiles all 220 translations cleanly with 0 unfinished.
- Form label updated to 'LLM Max Results:' / 'LLM 最大结果数：' with explanatory tooltip.