### PR TITLE
fix(audio): set explicit mono channel position and add state_changed logging (#169)

### DIFF
--- a/.agents/skills/vinput-dev/references/audio-debugging.md
+++ b/.agents/skills/vinput-dev/references/audio-debugging.md
@@ -7,9 +7,17 @@
 ```bash
 # Follow live daemon logs via systemd user service
 journalctl --user -u vinput-daemon.service -f -n 100
+# or via CLI
+vinput daemon logs -f
 
 # Run daemon directly in foreground for interactive debugging
-vinput-daemon --debug
+vinput daemon stop
+VINPUT_DEBUG=1 vinput-daemon
+
+# Or enable debug logging for the systemd user service
+systemctl --user set-environment VINPUT_DEBUG=1
+vinput daemon restart
+vinput daemon logs -f
 ```
 
 ---

--- a/src/daemon/audio/audio_capture.cpp
+++ b/src/daemon/audio/audio_capture.cpp
@@ -4,7 +4,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <pipewire/stream.h>
 #include <spa/param/audio/format-utils.h>
+#include <spa/param/audio/raw.h>
 #include <spa/pod/builder.h>
 
 #include "common/utils/debug_log.h"
@@ -152,6 +154,19 @@ void AudioCapture::onParamChanged(void* userdata, uint32_t id, const struct spa_
           info.channels, info.format);
 }
 
+void AudioCapture::onStateChanged(void* userdata, enum pw_stream_state old,
+                                  enum pw_stream_state state, const char* error) {
+  (void)userdata;
+  const char* err_str = (error != nullptr && error[0] != '\0') ? error : nullptr;
+  vinput::debug::Log("capture stream state: %s -> %s%s%s\n", pw_stream_state_as_string(old),
+                     pw_stream_state_as_string(state), err_str != nullptr ? " error=" : "",
+                     err_str != nullptr ? err_str : "");
+  if (state == PW_STREAM_STATE_ERROR) {
+    fprintf(stderr, "vinput: PipeWire stream error: %s\n",
+            err_str != nullptr ? err_str : "unknown error");
+  }
+}
+
 bool AudioCapture::Start(std::string* error) {
   if (loop_) {
     return true;
@@ -210,6 +225,7 @@ bool AudioCapture::CreateStream(bool start_inactive, std::string* error) {
   stream_events_.version = PW_VERSION_STREAM_EVENTS;
   stream_events_.param_changed = onParamChanged;
   stream_events_.process = onProcess;
+  stream_events_.state_changed = onStateChanged;
 
   std::string target_object = CurrentTargetObject();
 
@@ -248,6 +264,7 @@ bool AudioCapture::CreateStream(bool start_inactive, std::string* error) {
   raw_info.format = SPA_AUDIO_FORMAT_S16_LE;
   raw_info.rate = 16000;
   raw_info.channels = 1;
+  raw_info.position[0] = SPA_AUDIO_CHANNEL_MONO;
   const struct spa_pod* params[1];
   params[0] = spa_format_audio_raw_build(&builder, SPA_PARAM_EnumFormat, &raw_info);
 

--- a/src/daemon/audio/audio_capture.h
+++ b/src/daemon/audio/audio_capture.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <pipewire/pipewire.h>
+#include <pipewire/stream.h>
 #include <pipewire/thread-loop.h>
 #include <spa/param/audio/format-utils.h>
 #include <span>
@@ -58,6 +59,8 @@ public:
 private:
   static void onProcess(void* userdata);
   static void onParamChanged(void* userdata, uint32_t id, const struct spa_pod* param);
+  static void onStateChanged(void* userdata, enum pw_stream_state old, enum pw_stream_state state,
+                             const char* error);
   bool CreateStream(bool start_inactive, std::string* error = nullptr);
   bool SetStreamActive(bool active, std::string* error = nullptr);
   void DestroyStream();


### PR DESCRIPTION
Closes #169

### Implementation Tasks
- [x] 1. Set explicit SPA_AUDIO_CHANNEL_MONO position and add state_changed listener in AudioCapture
- [x] 2. Update audio debugging reference docs to use VINPUT_DEBUG=1

### Validation
- In `AudioCapture::CreateStream`, set `raw_info.position[0] = SPA_AUDIO_CHANNEL_MONO` so session managers (like WirePlumber 0.4.8 on Ubuntu 22.04) can downmix and link stereo capture nodes (`FL, FR`) to our single-channel capture stream.
- In `AudioCapture::CreateStream`, registered `onStateChanged` listener to log stream state transitions and surface any PipeWire errors.
- Corrected `.agents/skills/vinput-dev/references/audio-debugging.md` to document `VINPUT_DEBUG=1` instead of unsupported `--debug` flag.
- Local static checks (`clang-format`, `hk`, `check-i18n.py`) all passed cleanly.