### PR TITLE
fix(gui): stretch QFormLayout combos under Breeze (#177)

### DIFF
--- a/src/gui/dialogs/adapter_dialog.cpp
+++ b/src/gui/dialogs/adapter_dialog.cpp
@@ -59,6 +59,7 @@ bool ShowAdapterDialog(QWidget* parent, const AdapterData& initial, AdapterData*
     auto* layout = new QVBoxLayout(&dialog);
 
     auto* form = new QFormLayout();
+    form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
     auto* editCommand = new QLineEdit();
     auto* textArgs = new QTextEdit();
     auto* textEnv = new QTextEdit();

--- a/src/gui/dialogs/asr_provider_dialog.cpp
+++ b/src/gui/dialogs/asr_provider_dialog.cpp
@@ -97,6 +97,7 @@ bool ShowAsrProviderDialog(QWidget* parent, const QString& title, const AsrProvi
     dialog.setWindowTitle(title);
 
     auto* form = new QFormLayout();
+    form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
     auto* editName = new QLineEdit();
     auto* comboType = new QComboBox();
     auto* comboModel = new QComboBox();

--- a/src/gui/pages/control/control_page.cpp
+++ b/src/gui/pages/control/control_page.cpp
@@ -131,6 +131,7 @@ ControlPage::ControlPage(QWidget* parent)
   audioLayout->addWidget(new QLabel(tr("<b>Audio</b>")));
 
   auto* formLayout = new QFormLayout();
+  formLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   comboDevice_ = new QComboBox();
   comboDevice_->setEditable(false);
   formLayout->addRow(tr("Capture Device:"), comboDevice_);

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -308,6 +308,7 @@ void LlmPage::onLlmAdd() {
   dialog.setWindowTitle(tr("Add LLM Provider"));
 
   auto* form = new QFormLayout();
+  form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* editName = new QLineEdit();
   auto* editBaseUrl = new QLineEdit();
   auto* editApiKey = new QLineEdit();
@@ -382,6 +383,7 @@ void LlmPage::onLlmEdit() {
   dialog.setWindowTitle(tr("Edit LLM Provider"));
 
   auto* form = new QFormLayout();
+  form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* editName = new QLineEdit(provider_name);
   editName->setReadOnly(true);
   auto* editBaseUrl = new QLineEdit(current_base_url);

--- a/src/gui/pages/llm/llm_page.cpp
+++ b/src/gui/pages/llm/llm_page.cpp
@@ -740,6 +740,7 @@ void LlmPage::onSceneAdd() {
   dialog.setWindowTitle(tr("Add Scene"));
 
   auto* form = new QFormLayout();
+  form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* editId = new QLineEdit();
   auto* editLabel = new QLineEdit();
   auto* editPrompt = new QTextEdit();
@@ -829,6 +830,7 @@ void LlmPage::onSceneEdit() {
   dialog.setWindowTitle(tr("Edit Scene"));
 
   auto* form = new QFormLayout();
+  form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* editId = new QLineEdit(scene_id);
   editId->setReadOnly(true);
   auto* editLabel = new QLineEdit(QString::fromStdString(found->label));


### PR DESCRIPTION
Closes #177

### Implementation Tasks
- [x] 1. Set `AllNonFixedFieldsGrow` on scene add/edit `QFormLayout`s in `llm_page.cpp`
- [x] 2. Apply the same `fieldGrowthPolicy` to other GUI `QFormLayout`s (LLM provider dialogs, ASR provider dialog, adapter dialog, control page)

Breeze uses `ExpandingFieldsGrow` so `QComboBox` (Preferred) stays content-sized; Fusion uses `AllNonFixedFieldsGrow` and stretches. Explicit policy keeps KDE and non-KDE themes consistent.