### PR TITLE
fix(gui): eliminate ghosting duplicate text in resource table README column (#185)

### DIFF
--- a/src/gui/pages/resources/resource_page.cpp
+++ b/src/gui/pages/resources/resource_page.cpp
@@ -487,7 +487,7 @@ void ResourcePage::populateRemoteProviders(
       linkLabel->setAlignment(Qt::AlignCenter);
       linkLabel->setStyleSheet(QStringLiteral("background: transparent;"));
       tableAvailableProviders_->setCellWidget(row, 4, linkLabel);
-      tableAvailableProviders_->setItem(row, 4, MakeCell(tr("Open README"), readme_url));
+      tableAvailableProviders_->setItem(row, 4, MakeCell(QString{}, readme_url));
     } else {
       auto* emptyCell = MakeCell(QStringLiteral("-"));
       emptyCell->setTextAlignment(Qt::AlignCenter);
@@ -533,7 +533,7 @@ void ResourcePage::populateRemoteAdapters(
       linkLabel->setAlignment(Qt::AlignCenter);
       linkLabel->setStyleSheet(QStringLiteral("background: transparent;"));
       tableAvailableAdapters_->setCellWidget(row, 3, linkLabel);
-      tableAvailableAdapters_->setItem(row, 3, MakeCell(tr("Open README"), readme_url));
+      tableAvailableAdapters_->setItem(row, 3, MakeCell(QString{}, readme_url));
     } else {
       auto* emptyCell = MakeCell(QStringLiteral("-"));
       emptyCell->setTextAlignment(Qt::AlignCenter);


### PR DESCRIPTION
Closes #185

### Implementation Tasks
- [x] 1. Clear underlying item display text when attaching README linkLabel cellWidget in ResourcePage
- [x] 2. Validate clean rendering, quality gates, and i18n checks