### PR TITLE
style(gui): use default theme text color with underline for table links (#191)

### DIFF
--- a/src/gui/pages/resources/resource_page.cpp
+++ b/src/gui/pages/resources/resource_page.cpp
@@ -61,9 +61,6 @@ public:
     initStyleOption(&opt, index);
     if (!index.data(Qt::UserRole).toString().isEmpty()) {
       opt.font.setUnderline(true);
-      if ((opt.state & QStyle::State_Selected) == 0) {
-        opt.palette.setColor(QPalette::Text, opt.palette.link().color());
-      }
     }
     QStyledItemDelegate::paint(painter, opt, index);
   }


### PR DESCRIPTION
Closes #191

### Implementation Tasks
- [x] 1. Remove explicit palette link color override and keep default text color with underline in LinkDelegate