### PR TITLE
feat(config): add isolated ConfigMigration engine and 'vinput config migrate' command (#197)

### DIFF
--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -221,7 +221,7 @@ _vinput() {
                 if [[ "$cur" == -* ]]; then
                     COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
                 else
-                    COMPREPLY=($(compgen -W "get set edit e" -- "$cur"))
+                    COMPREPLY=($(compgen -W "get set edit e migrate" -- "$cur"))
                 fi
             else
                 case "${words[2]}" in

--- a/data/completions/bash/vinput
+++ b/data/completions/bash/vinput
@@ -231,6 +231,9 @@ _vinput() {
                     set)
                         COMPREPLY=($(compgen -W "-i --stdin" -- "$cur"))
                         ;;
+                    migrate)
+                        COMPREPLY=($(compgen -W "-n --dry-run -h --help" -- "$cur"))
+                        ;;
                 esac
             fi
             return 0

--- a/data/completions/fish/vinput.fish
+++ b/data/completions/fish/vinput.fish
@@ -128,9 +128,11 @@ complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcom
 complete -c vinput -n "__fish_seen_subcommand_from scene; and __fish_seen_subcommand_from add edit e" -l raw-prev -a "true false" -d "Preview raw ASR transcript in floating panel during postprocessing (true/false)"
 
 # config
-complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e" -a get -d "Get a config value by JSON Pointer"
-complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e" -a set -d "Set a config value by JSON Pointer"
-complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e" -a "edit e" -d "Open config in editor"
+complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e migrate" -a get -d "Get a config value by JSON Pointer"
+complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e migrate" -a set -d "Set a config value by JSON Pointer"
+complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e migrate" -a "edit e" -d "Open config in editor"
+complete -c vinput -n "__fish_seen_subcommand_from config; and not __fish_seen_subcommand_from get set edit e migrate" -a migrate -d "Migrate legacy configuration files to current format"
+complete -c vinput -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from migrate" -s n -l dry-run -d "Preview migration changes without modifying files"
 complete -c vinput -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from edit e" -a "core fcitx"
 complete -c vinput -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -s i -l stdin -d "Read value from stdin"
 

--- a/data/completions/zsh/_vinput
+++ b/data/completions/zsh/_vinput
@@ -179,6 +179,7 @@ _vinput_config_cmds() {
         'set:Set a config value by JSON Pointer'
         'edit:Open config file in editor'
         'e:Open config file in editor'
+        'migrate:Migrate legacy configuration files to current format'
     )
     _describe -t config_cmds 'config command' config_cmds
 }
@@ -387,6 +388,10 @@ _vinput() {
                                     _arguments \
                                         '(-h --help)'{-h,--help}'[Print help message and exit]' \
                                         '1:path:' ;;
+                                migrate)
+                                    _arguments \
+                                        '(-h --help)'{-h,--help}'[Print help message and exit]' \
+                                        '(-n --dry-run)'{-n,--dry-run}'[Preview migration changes without modifying files]' ;;
                             esac
                             ;;
                     esac

--- a/data/man/en/vinput.1
+++ b/data/man/en/vinput.1
@@ -186,6 +186,11 @@ Open the configuration file in \f[CR]$EDITOR\f[R].
 \f[I]TARGET\f[R] must be either \f[B]core\f[R]
 (\f[I]\(ti/.config/vinput/config.json\f[R]) or \f[B]fcitx\f[R]
 (\f[I]\(ti/.config/fcitx5/conf/vinput.conf\f[R]).
+.TP
+\f[B]config migrate\f[R] [\f[B]\-n\f[R], \f[B]\-\-dry\-run\f[R]]
+Migrate legacy configuration files in\-place to the latest format (with
+automatic backups saved under \f[CR]backups/\f[R]).
+Pass \f[B]\-n\f[R] to preview pending changes without modifying files.
 .SS DAEMON CONTROL
 .TP
 \f[B]daemon status\f[R]

--- a/data/man/en/vinput.1.md
+++ b/data/man/en/vinput.1.md
@@ -166,6 +166,9 @@ Scenes define prompt templates and bound LLM configurations used to rewrite raw 
 **config edit** *TARGET*
 :   Open the configuration file in `$EDITOR`. *TARGET* must be either **core** (*~/.config/vinput/config.json*) or **fcitx** (*~/.config/fcitx5/conf/vinput.conf*).
 
+**config migrate** [**-n**, **--dry-run**]
+:   Migrate legacy configuration files in-place to the latest format (with automatic backups saved under `backups/`). Pass **-n** to preview pending changes without modifying files.
+
 ## DAEMON CONTROL
 **daemon status**
 :   Show the runtime status of **vinput-daemon** (PID, active model, D-Bus connection).

--- a/data/man/zh_CN/vinput.1
+++ b/data/man/zh_CN/vinput.1
@@ -173,6 +173,11 @@ ASR 识别出的原始文本进行重写与润色。
 在 \f[CR]$EDITOR\f[R] 中打开配置文件。\f[I]TARGET\f[R] 必须为
 \f[B]core\f[R]（\f[I]\(ti/.config/vinput/config.json\f[R]）或
 \f[B]fcitx\f[R]（\f[I]\(ti/.config/fcitx5/conf/vinput.conf\f[R]）。
+.TP
+\f[B]config migrate\f[R] [\f[B]\-n\f[R], \f[B]\-\-dry\-run\f[R]]
+将旧版配置文件平滑迁移至当前最新格式（自动备份原配置文件至
+\f[CR]backups/\f[R]）。传入 \f[B]\-n\f[R]
+可预览将要进行的改动而不写入文件。
 .SS 守护进程控制
 .TP
 \f[B]daemon status\f[R]

--- a/data/man/zh_CN/vinput.1.md
+++ b/data/man/zh_CN/vinput.1.md
@@ -166,6 +166,9 @@ vinput - fcitx5-vinput 命令行控制与管理工具
 **config edit** *TARGET*
 :   在 `$EDITOR` 中打开配置文件。*TARGET* 必须为 **core**（*~/.config/vinput/config.json*）或 **fcitx**（*~/.config/fcitx5/conf/vinput.conf*）。
 
+**config migrate** [**-n**, **--dry-run**]
+:   将旧版配置文件平滑迁移至当前最新格式（自动备份原配置文件至 `backups/`）。传入 **-n** 可预览将要进行的改动而不写入文件。
+
 ## 守护进程控制
 **daemon status**
 :   查看 **vinput-daemon** 的运行状态（PID、活动模型、D-Bus 连接等）。

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1183,3 +1183,32 @@ msgstr "未配置活跃的 ASR 提供商。"
 
 msgid "Recording is not active."
 msgstr "当前未在录音。"
+
+#, c-format
+msgid "Backed up addon config to: %s"
+msgstr "插件配置已备份至：%s"
+
+#, c-format
+msgid "Backed up core config to: %s"
+msgstr "核心配置已备份至：%s"
+
+msgid "CHANGE"
+msgstr "变更内容"
+
+msgid "Configuration is already up to date. No migration needed."
+msgstr "配置已经是最新版本，无需迁移。"
+
+msgid "Configuration migration completed successfully:"
+msgstr "配置迁移已顺利完成："
+
+msgid "FILE"
+msgstr "文件"
+
+msgid "Migrate legacy configuration files to current format"
+msgstr "将旧版配置文件迁移至当前格式"
+
+msgid "Pending migration changes:"
+msgstr "待应用的迁移变更："
+
+msgid "Preview migration changes without modifying files"
+msgstr "预览迁移变更而不修改文件"

--- a/src/cli/config/config_actions.cpp
+++ b/src/cli/config/config_actions.cpp
@@ -4,8 +4,10 @@
 #include <iostream>
 #include <string>
 
+#include "common/config/config_migration.h"
 #include "common/config/config_router.h"
 #include "common/i18n.h"
+#include "common/utils/string_utils.h"
 
 #include "cli/utils/editor_utils.h"
 
@@ -53,4 +55,60 @@ int RunConfigDomainEdit(const std::string& target, Formatter& fmt, const CliCont
   }
   auto file_path = vinput::config::GetEditTarget(target);
   return OpenInEditor(file_path);
+}
+
+int RunConfigMigrate(bool dry_run, Formatter& fmt, const CliContext& ctx) {
+  const auto report = vinput::migration::RunConfigMigration(dry_run);
+
+  if (!report.error.empty()) {
+    fmt.PrintError(report.error);
+    return 1;
+  }
+
+  if (ctx.json_output) {
+    nlohmann::json j;
+    j["needed"] = report.needed;
+    j["applied"] = report.applied;
+    j["dry_run"] = dry_run;
+    j["config_file"] = report.config_file.string();
+    j["conf_file"] = report.conf_file.string();
+    j["config_backup"] = report.config_backup.string();
+    j["conf_backup"] = report.conf_backup.string();
+    nlohmann::json changes = nlohmann::json::array();
+    for (const auto& ch : report.changes) {
+      changes.push_back({{"file", ch.file}, {"description", ch.description}});
+    }
+    j["changes"] = changes;
+    fmt.PrintJson(j);
+    return 0;
+  }
+
+  if (!report.needed) {
+    fmt.PrintSuccess(_("Configuration is already up to date. No migration needed."));
+    return 0;
+  }
+
+  if (dry_run) {
+    fmt.PrintSuccess(_("Pending migration changes:"));
+  } else {
+    fmt.PrintSuccess(_("Configuration migration completed successfully:"));
+  }
+
+  if (!report.config_backup.empty()) {
+    fmt.PrintInfo(
+        vinput::str::FmtStr(_("Backed up core config to: %s"), report.config_backup.c_str()));
+  }
+  if (!report.conf_backup.empty()) {
+    fmt.PrintInfo(
+        vinput::str::FmtStr(_("Backed up addon config to: %s"), report.conf_backup.c_str()));
+  }
+
+  const std::vector<std::string> headers = {_("FILE"), _("CHANGE")};
+  std::vector<std::vector<std::string>> rows;
+  for (const auto& ch : report.changes) {
+    rows.push_back({ch.file, ch.description});
+  }
+  fmt.PrintTable(headers, rows);
+
+  return 0;
 }

--- a/src/cli/config/config_actions.cpp
+++ b/src/cli/config/config_actions.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "common/config/config_migration.h"
 #include "common/config/config_router.h"
@@ -75,6 +76,7 @@ int RunConfigMigrate(bool dry_run, Formatter& fmt, const CliContext& ctx) {
     j["config_backup"] = report.config_backup.string();
     j["conf_backup"] = report.conf_backup.string();
     nlohmann::json changes = nlohmann::json::array();
+    changes.get_ptr<nlohmann::json::array_t*>()->reserve(report.changes.size());
     for (const auto& ch : report.changes) {
       changes.push_back({{"file", ch.file}, {"description", ch.description}});
     }
@@ -105,6 +107,7 @@ int RunConfigMigrate(bool dry_run, Formatter& fmt, const CliContext& ctx) {
 
   const std::vector<std::string> headers = {_("FILE"), _("CHANGE")};
   std::vector<std::vector<std::string>> rows;
+  rows.reserve(report.changes.size());
   for (const auto& ch : report.changes) {
     rows.push_back({ch.file, ch.description});
   }

--- a/src/cli/config/config_actions.h
+++ b/src/cli/config/config_actions.h
@@ -9,3 +9,4 @@ int RunConfigDomainGet(const std::string& path, Formatter& fmt, const CliContext
 int RunConfigDomainSet(const std::string& path, const std::string& value, bool from_stdin,
                        Formatter& fmt, const CliContext& ctx);
 int RunConfigDomainEdit(const std::string& target, Formatter& fmt, const CliContext& ctx);
+int RunConfigMigrate(bool dry_run, Formatter& fmt, const CliContext& ctx);

--- a/src/cli/config/register_config.cpp
+++ b/src/cli/config/register_config.cpp
@@ -43,6 +43,17 @@ void RegisterConfigCommands(CLI::App& app, CliAction* action) {
       return RunConfigDomainEdit(*editTarget, fmt, ctx);
     };
   });
+
+  auto dryRun = std::make_shared<bool>(false);
+  auto* migrate =
+      config->add_subcommand("migrate", _("Migrate legacy configuration files to current format"));
+  migrate->add_flag("-n,--dry-run", *dryRun,
+                    _("Preview migration changes without modifying files"));
+  migrate->callback([action, dryRun]() {
+    *action = [dryRun](Formatter& fmt, const CliContext& ctx) {
+      return RunConfigMigrate(*dryRun, fmt, ctx);
+    };
+  });
 }
 
 } // namespace vinput::cli::config

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -6,6 +6,7 @@ set(VINPUT_CONFIG_SOURCES
     config/core_config_resolve.cpp
     config/core_config_json.cpp
     config/config_router.cpp
+    config/config_migration.cpp
     config/vinput_config.cpp
     scene/postprocess_scene.cpp
     llm/provider_model_cache.cpp

--- a/src/common/config/config_migration.cpp
+++ b/src/common/config/config_migration.cpp
@@ -226,15 +226,19 @@ MigrationReport RunConfigMigration(bool dry_run, const std::filesystem::path& co
   std::string ini_content;
   bool has_ini = false;
   if (std::filesystem::exists(report.conf_file)) {
-    if (vinput::file::ReadTextFile(report.conf_file, &ini_content, &read_error)) {
-      has_ini = true;
+    if (!vinput::file::ReadTextFile(report.conf_file, &ini_content, &read_error)) {
+      report.error = "Failed to read " + report.conf_file.string() + ": " + read_error;
+      return report;
     }
+    has_ini = true;
   }
 
   if (!has_json && !has_ini) {
     report.needed = false;
     return report;
   }
+
+  const std::string original_ini = ini_content;
 
   for (const auto& step : RegisteredSteps()) {
     step.apply(root_json, ini_content, report.changes);
@@ -250,35 +254,51 @@ MigrationReport RunConfigMigration(bool dry_run, const std::filesystem::path& co
     return report;
   }
 
+  bool json_changed = false;
+  bool ini_changed = false;
+  for (const auto& ch : report.changes) {
+    if (ch.file == "config.json") {
+      json_changed = true;
+    } else if (ch.file == "vinput.conf") {
+      ini_changed = true;
+    }
+  }
+
   const std::string ts = CurrentTimestampStr();
 
-  // 1. Back up and write config.json
-  if (has_json) {
-    const auto backup_dir = report.config_file.parent_path() / "backups";
+  // Back up originals before rewriting any live config file.
+  if (json_changed && has_json) {
+    const auto backup_file =
+        report.config_file.parent_path() / "backups" / ("config.json.bak." + ts);
     std::string err;
-    vinput::file::EnsureParentDirectory(backup_dir / "placeholder", &err);
-    const auto backup_file = backup_dir / ("config.json.bak." + ts);
-    if (vinput::file::AtomicWriteTextFile(backup_file, json_content, &err)) {
-      report.config_backup = backup_file;
+    if (!vinput::file::AtomicWriteTextFile(backup_file, json_content, &err)) {
+      report.error = "Failed to back up " + report.config_file.string() + ": " + err;
+      return report;
     }
+    report.config_backup = backup_file;
+  }
 
+  if (ini_changed && has_ini) {
+    const auto backup_file = report.conf_file.parent_path() / "backups" / ("vinput.conf.bak." + ts);
+    std::string err;
+    if (!vinput::file::AtomicWriteTextFile(backup_file, original_ini, &err)) {
+      report.error = "Failed to back up " + report.conf_file.string() + ": " + err;
+      return report;
+    }
+    report.conf_backup = backup_file;
+  }
+
+  if (json_changed && has_json) {
     const std::string updated_json = root_json.dump(4) + "\n";
+    std::string err;
     if (!vinput::file::AtomicWriteTextFile(report.config_file, updated_json, &err)) {
       report.error = "Failed to write updated " + report.config_file.string() + ": " + err;
       return report;
     }
   }
 
-  // 2. Back up and write vinput.conf
-  if (has_ini) {
-    const auto backup_dir = report.conf_file.parent_path() / "backups";
+  if (ini_changed && has_ini) {
     std::string err;
-    vinput::file::EnsureParentDirectory(backup_dir / "placeholder", &err);
-    const auto backup_file = backup_dir / ("vinput.conf.bak." + ts);
-    if (vinput::file::AtomicWriteTextFile(backup_file, ini_content, &err)) {
-      report.conf_backup = backup_file;
-    }
-
     if (!vinput::file::AtomicWriteTextFile(report.conf_file, ini_content + "\n", &err)) {
       report.error = "Failed to write updated " + report.conf_file.string() + ": " + err;
       return report;

--- a/src/common/config/config_migration.cpp
+++ b/src/common/config/config_migration.cpp
@@ -2,14 +2,16 @@
 
 #include <chrono>
 #include <ctime>
+#include <exception>
 #include <filesystem>
-#include <fstream>
 #include <functional>
 #include <iomanip>
 #include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "common/utils/file_utils.h"

--- a/src/common/config/config_migration.cpp
+++ b/src/common/config/config_migration.cpp
@@ -1,0 +1,290 @@
+#include "common/config/config_migration.h"
+
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "common/utils/file_utils.h"
+#include "common/utils/path_utils.h"
+
+namespace vinput::migration {
+
+namespace {
+
+using json = nlohmann::json;
+
+void RenameField(json& obj, std::string_view old_name, std::string_view new_name,
+                 std::string_view context_desc, std::vector<MigrationChange>& changes) {
+  if (!obj.is_object()) {
+    return;
+  }
+  auto it = obj.find(old_name);
+  if (it != obj.end()) {
+    if (!obj.contains(new_name)) {
+      obj[std::string(new_name)] = std::move(*it);
+      changes.push_back({"config.json", std::string(context_desc) + ": renamed '" +
+                                            std::string(old_name) + "' to '" +
+                                            std::string(new_name) + "'"});
+    }
+    obj.erase(it);
+  }
+}
+
+void RenameFieldInArray(json& arr, std::string_view old_name, std::string_view new_name,
+                        std::string_view array_desc, std::vector<MigrationChange>& changes) {
+  if (!arr.is_array()) {
+    return;
+  }
+  for (size_t i = 0; i < arr.size(); ++i) {
+    if (arr[i].is_object()) {
+      std::string desc = std::string(array_desc) + "[" + std::to_string(i) + "]";
+      if (arr[i].contains("id") && arr[i]["id"].is_string()) {
+        desc += " (" + arr[i]["id"].get<std::string>() + ")";
+      }
+      RenameField(arr[i], old_name, new_name, desc, changes);
+    }
+  }
+}
+
+template <typename T>
+void EnsureFieldInArray(json& arr, std::string_view field_name, const T& default_val,
+                        std::string_view array_desc, std::vector<MigrationChange>& changes) {
+  if (!arr.is_array()) {
+    return;
+  }
+  for (size_t i = 0; i < arr.size(); ++i) {
+    if (arr[i].is_object() && !arr[i].contains(field_name)) {
+      arr[i][std::string(field_name)] = default_val;
+      std::string desc = std::string(array_desc) + "[" + std::to_string(i) + "]";
+      if (arr[i].contains("id") && arr[i]["id"].is_string()) {
+        desc += " (" + arr[i]["id"].get<std::string>() + ")";
+      }
+      changes.push_back({"config.json", desc + ": added '" + std::string(field_name) + "'"});
+    }
+  }
+}
+
+bool StartsWithKey(std::string_view line, std::string_view key) {
+  if (!line.starts_with(key)) {
+    return false;
+  }
+  if (line.size() == key.size()) {
+    return false;
+  }
+  const char next = line[key.size()];
+  return next == '=' || next == ' ' || next == '\t';
+}
+
+void ReplaceIniKey(std::string& ini_text, std::string_view old_key, std::string_view new_key,
+                   std::vector<MigrationChange>& changes) {
+  std::istringstream iss(ini_text);
+  std::ostringstream oss;
+  std::string line;
+  bool replaced = false;
+
+  while (std::getline(iss, line)) {
+    if (!replaced && StartsWithKey(line, old_key)) {
+      const auto eq = line.find('=');
+      if (eq != std::string::npos) {
+        oss << new_key << line.substr(eq) << "\n";
+        replaced = true;
+        changes.push_back({"vinput.conf", "replaced key '" + std::string(old_key) + "' with '" +
+                                              std::string(new_key) + "'"});
+        continue;
+      }
+    }
+    oss << line << "\n";
+  }
+
+  if (replaced) {
+    ini_text = oss.str();
+    if (!ini_text.empty() && ini_text.back() == '\n') {
+      ini_text.pop_back();
+    }
+  }
+}
+
+void RemoveIniKey(std::string& ini_text, std::string_view key,
+                  std::vector<MigrationChange>& changes) {
+  std::istringstream iss(ini_text);
+  std::ostringstream oss;
+  std::string line;
+  bool removed = false;
+
+  while (std::getline(iss, line)) {
+    if (StartsWithKey(line, key)) {
+      removed = true;
+      changes.push_back({"vinput.conf", "removed obsolete key '" + std::string(key) + "'"});
+      continue;
+    }
+    oss << line << "\n";
+  }
+
+  if (removed) {
+    ini_text = oss.str();
+    if (!ini_text.empty() && ini_text.back() == '\n') {
+      ini_text.pop_back();
+    }
+  }
+}
+
+std::string CurrentTimestampStr() {
+  const auto now = std::chrono::system_clock::now();
+  const auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  std::tm tm_now{};
+  localtime_r(&time_t_now, &tm_now);
+  std::ostringstream oss;
+  oss << std::put_time(&tm_now, "%Y%m%d-%H%M%S");
+  return oss.str();
+}
+
+struct MigrationStep {
+  std::string_view version;
+  std::string_view description;
+  std::function<void(json& j, std::string& ini, std::vector<MigrationChange>& changes)> apply;
+};
+
+const std::vector<MigrationStep>& RegisteredSteps() {
+  static const std::vector<MigrationStep> kSteps = {
+      {
+          "v2.3.15",
+          "Normalize candidate_count to count and unify hotkeys into MenuKey",
+          [](json& j, std::string& ini, std::vector<MigrationChange>& ch) {
+            if (j.contains("scenes") && j["scenes"].is_object()) {
+              RenameFieldInArray(j["scenes"]["definitions"], "candidate_count", "count",
+                                 "scenes.definitions", ch);
+              RenameFieldInArray(j["scenes"]["items"], "candidate_count", "count", "scenes.items",
+                                 ch);
+            }
+            if (j.contains("llm") && j["llm"].is_object()) {
+              RenameField(j["llm"], "adaptors", "adapters", "llm", ch);
+            }
+            ReplaceIniKey(ini, "SceneMenuKey", "MenuKey", ch);
+            RemoveIniKey(ini, "AsrMenuKey", ch);
+          },
+      },
+      {
+          "v2.3.25",
+          "Decouple show_raw into raw_cand and raw_prev",
+          [](json& j, std::string& /*ini*/, std::vector<MigrationChange>& ch) {
+            if (j.contains("scenes") && j["scenes"].is_object()) {
+              RenameFieldInArray(j["scenes"]["definitions"], "show_raw", "raw_cand",
+                                 "scenes.definitions", ch);
+              RenameFieldInArray(j["scenes"]["items"], "show_raw", "raw_cand", "scenes.items", ch);
+              EnsureFieldInArray(j["scenes"]["definitions"], "raw_prev", true, "scenes.definitions",
+                                 ch);
+              EnsureFieldInArray(j["scenes"]["items"], "raw_prev", true, "scenes.items", ch);
+            }
+          },
+      },
+  };
+  return kSteps;
+}
+
+} // namespace
+
+bool HasPendingMigrations(const std::filesystem::path& config_path,
+                          const std::filesystem::path& conf_path) {
+  const auto report = RunConfigMigration(true, config_path, conf_path);
+  return report.needed;
+}
+
+MigrationReport RunConfigMigration(bool dry_run, const std::filesystem::path& config_path,
+                                   const std::filesystem::path& conf_path) {
+  MigrationReport report;
+  report.config_file = config_path.empty() ? vinput::path::CoreConfigPath() : config_path;
+  report.conf_file = conf_path.empty() ? vinput::path::FcitxAddonConfigPath() : conf_path;
+
+  json root_json;
+  bool has_json = false;
+  std::string json_content;
+  std::string read_error;
+  if (std::filesystem::exists(report.config_file)) {
+    if (!vinput::file::ReadTextFile(report.config_file, &json_content, &read_error)) {
+      report.error = "Failed to read " + report.config_file.string() + ": " + read_error;
+      return report;
+    }
+    try {
+      root_json = json::parse(json_content);
+      has_json = true;
+    } catch (const std::exception& ex) {
+      report.error = "Failed to parse " + report.config_file.string() + ": " + ex.what();
+      return report;
+    }
+  }
+
+  std::string ini_content;
+  bool has_ini = false;
+  if (std::filesystem::exists(report.conf_file)) {
+    if (vinput::file::ReadTextFile(report.conf_file, &ini_content, &read_error)) {
+      has_ini = true;
+    }
+  }
+
+  if (!has_json && !has_ini) {
+    report.needed = false;
+    return report;
+  }
+
+  for (const auto& step : RegisteredSteps()) {
+    step.apply(root_json, ini_content, report.changes);
+  }
+
+  if (report.changes.empty()) {
+    report.needed = false;
+    return report;
+  }
+
+  report.needed = true;
+  if (dry_run) {
+    return report;
+  }
+
+  const std::string ts = CurrentTimestampStr();
+
+  // 1. Back up and write config.json
+  if (has_json) {
+    const auto backup_dir = report.config_file.parent_path() / "backups";
+    std::string err;
+    vinput::file::EnsureParentDirectory(backup_dir / "placeholder", &err);
+    const auto backup_file = backup_dir / ("config.json.bak." + ts);
+    if (vinput::file::AtomicWriteTextFile(backup_file, json_content, &err)) {
+      report.config_backup = backup_file;
+    }
+
+    const std::string updated_json = root_json.dump(4) + "\n";
+    if (!vinput::file::AtomicWriteTextFile(report.config_file, updated_json, &err)) {
+      report.error = "Failed to write updated " + report.config_file.string() + ": " + err;
+      return report;
+    }
+  }
+
+  // 2. Back up and write vinput.conf
+  if (has_ini) {
+    const auto backup_dir = report.conf_file.parent_path() / "backups";
+    std::string err;
+    vinput::file::EnsureParentDirectory(backup_dir / "placeholder", &err);
+    const auto backup_file = backup_dir / ("vinput.conf.bak." + ts);
+    if (vinput::file::AtomicWriteTextFile(backup_file, ini_content, &err)) {
+      report.conf_backup = backup_file;
+    }
+
+    if (!vinput::file::AtomicWriteTextFile(report.conf_file, ini_content + "\n", &err)) {
+      report.error = "Failed to write updated " + report.conf_file.string() + ": " + err;
+      return report;
+    }
+  }
+
+  report.applied = true;
+  return report;
+}
+
+} // namespace vinput::migration

--- a/src/common/config/config_migration.h
+++ b/src/common/config/config_migration.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace vinput::migration {
+
+struct MigrationChange {
+  std::string file;
+  std::string description;
+};
+
+struct MigrationReport {
+  bool needed = false;
+  bool applied = false;
+  std::filesystem::path config_file;
+  std::filesystem::path conf_file;
+  std::filesystem::path config_backup;
+  std::filesystem::path conf_backup;
+  std::vector<MigrationChange> changes;
+  std::string error;
+};
+
+// Check if any registered migration steps have pending modifications.
+bool HasPendingMigrations(const std::filesystem::path& config_path = {},
+                          const std::filesystem::path& conf_path = {});
+
+// Run all registered migrations in order, with automatic backups before modifying files.
+MigrationReport RunConfigMigration(bool dry_run = false,
+                                   const std::filesystem::path& config_path = {},
+                                   const std::filesystem::path& conf_path = {});
+
+} // namespace vinput::migration


### PR DESCRIPTION
Closes #197

### Implementation Tasks
- [x] 1. Implement isolated ConfigMigration engine in common/config/
- [x] 2. Implement vinput config migrate CLI subcommand
- [x] 3. Update shell completions, man pages, and i18n