### PR TITLE
ci: decouple cpp-linter execution and PR comment posting via workflow_run

### DIFF
--- a/.github/workflows/cpp-linter-comment.yml
+++ b/.github/workflows/cpp-linter-comment.yml
@@ -1,0 +1,104 @@
+name: cpp-linter-comment
+
+on:
+  workflow_run:
+    workflows: ["cpp-linter"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: cpp-linter-comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  post-comment:
+    name: Post or update linter comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-report
+          path: pr-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+        id: download
+
+      - name: Post or update comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const prNumFile = path.join('pr-report', 'pr_number');
+            if (!fs.existsSync(prNumFile)) {
+              console.log('No pr_number file found, skipping.');
+              return;
+            }
+
+            const prNumber = parseInt(fs.readFileSync(prNumFile, 'utf8').trim(), 10);
+            if (isNaN(prNumber) || prNumber <= 0) {
+              console.log('Invalid PR number:', prNumber);
+              return;
+            }
+
+            const formatFailed = parseInt(fs.readFileSync(path.join('pr-report', 'format_failed'), 'utf8').trim() || '0', 10);
+            const tidyFailed = parseInt(fs.readFileSync(path.join('pr-report', 'tidy_failed'), 'utf8').trim() || '0', 10);
+            const runId = '${{ github.event.workflow_run.id }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
+
+            const marker = '<!-- cpp-linter-status-comment -->';
+            let body = `${marker}\n### 🔍 C++ Code Quality Report (cpp-linter)\n\n`;
+
+            if (formatFailed === 0 && tidyFailed === 0) {
+              body += `✅ **All C++ checks passed cleanly!**\n\n`;
+              body += `- **Clang-Format**: Pass ✨\n`;
+              body += `- **Clang-Tidy**: Pass ✨\n\n`;
+              body += `[View Workflow Run Summary](${runUrl})`;
+            } else {
+              body += `⚠️ **C++ style or static analysis issues detected:**\n\n`;
+              if (formatFailed > 0) {
+                body += `- ❌ **Clang-Format**: ${formatFailed} issue(s) detected. Run \`mise run fix\` or \`clang-format -i\` locally.\n`;
+              } else {
+                body += `- ✅ **Clang-Format**: Pass ✨\n`;
+              }
+              if (tidyFailed > 0) {
+                body += `- ❌ **Clang-Tidy**: ${tidyFailed} issue(s) detected. Run \`mise run tidy\` locally to inspect.\n`;
+              } else {
+                body += `- ✅ **Clang-Tidy**: Pass ✨\n`;
+              }
+              body += `\n> Line-by-line annotations are available in the [Files changed tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}/files) and [Workflow Run Summary](${runUrl}).`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+              console.log(`Updated existing comment ${existing.id} on PR #${prNumber}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+              console.log(`Created new comment on PR #${prNumber}`);
+            }

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: cpp-linter-${{ github.ref }}
@@ -49,7 +48,23 @@ jobs:
           files-changed-only: true
           step-summary: true
           file-annotations: true
-          thread-comments: 'update'
+          thread-comments: 'false'
+
+      - name: Save PR info and report
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          mkdir -p pr-report
+          echo "${{ github.event.pull_request.number }}" > pr-report/pr_number
+          echo "${{ steps.linter.outputs.clang-format-checks-failed }}" > pr-report/format_failed
+          echo "${{ steps.linter.outputs.clang-tidy-checks-failed }}" > pr-report/tidy_failed
+
+      - name: Upload artifact for PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-report
+          path: pr-report/
+          retention-days: 1
 
       - name: Fail on formatting or tidy violations
         if: steps.linter.outputs.clang-format-checks-failed > 0 || steps.linter.outputs.clang-tidy-checks-failed > 0


### PR DESCRIPTION
### Summary of Changes
- Decouple `cpp-linter` execution and PR comment posting to resolve 403 errors on forked PRs.
- In `cpp-linter.yml`: run in read-only sandbox (`contents: read`) with `thread-comments: 'false'`, uploading the lint results as an artifact.
- Add `cpp-linter-comment.yml`: triggered on `workflow_run` in the default branch context with `issues: write` / `pull-requests: write`, posting or updating in-place status comments on both internal and forked PRs without 403 permission failures.
- Preserve line-by-line annotations and step summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated pull request status comments summarizing Clang-Format and Clang-Tidy results.
  - Existing status comments are updated when new lint results are available.

- **Bug Fixes**
  - Improved handling of missing or invalid pull request information and unavailable lint reports.
  - Lint results are now preserved as downloadable artifacts for reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->