### PR TITLE
fix(addon): preserve raw_prev=false during busy state transitions (#208)

### DIFF
--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -32,8 +32,11 @@
 
 class VinputNotifierDBusObject;
 
+class VinputTestAccessor;
+
 class VinputEngine : public fcitx::AddonInstance {
 public:
+  friend class VinputTestAccessor;
   VinputEngine(fcitx::Instance* instance);
   ~VinputEngine() override;
   void selectPaletteItem(std::size_t index, fcitx::InputContext* ic);

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -96,7 +96,7 @@ private:
                               bool command_mode);
   void enterRecordingState(fcitx::InputContext* ic, const fcitx::Key& trigger, bool command_mode);
   void enterBusyState(fcitx::InputContext* ic, bool command_mode, const std::string& preedit_text,
-                      bool postprocessing = false, bool raw_prev = true);
+                      bool postprocessing = false, std::optional<bool> raw_prev = std::nullopt);
   void finishFrontendSession(fcitx::InputContext* fallback_ic = nullptr);
   void syncFrontendWithDaemonStatus(fcitx::InputContext* fallback_ic = nullptr,
                                     bool prefer_command_mode = false);

--- a/src/addon/core/vinput.h
+++ b/src/addon/core/vinput.h
@@ -80,6 +80,7 @@ private:
   bool callStopAdapter(const std::string& adapter_id, std::string* error = nullptr);
   void onRecognitionResult(fcitx::dbus::Message& msg);
   void onRecognitionPartial(fcitx::dbus::Message& msg);
+  void handleRecognitionPartial(const std::string& transcript_text);
   void onStatusChanged(fcitx::dbus::Message& msg);
   void onDaemonNotification(fcitx::dbus::Message& msg);
   void showDaemonNotification(const vinput::dbus::ErrorInfo& notification);

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -4,6 +4,7 @@
 #include <fcitx-utils/dbus/message.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputpanel.h>
+#include <optional>
 #include <string>
 #include <tuple>
 
@@ -13,6 +14,7 @@
 #include "common/dbus/error_info.h"
 #include "common/i18n.h"
 #include "common/runtime/runtime_defaults.h"
+#include "common/scene/postprocess_scene.h"
 #include "common/utils/debug_log.h"
 #include "common/utils/path_utils.h"
 #include "common/utils/string_utils.h"

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -917,7 +917,10 @@ void VinputEngine::onRecognitionResult(fcitx::dbus::Message& msg) {
 void VinputEngine::onRecognitionPartial(fcitx::dbus::Message& msg) {
   std::string transcript_text;
   msg >> transcript_text;
+  handleRecognitionPartial(transcript_text);
+}
 
+void VinputEngine::handleRecognitionPartial(const std::string& transcript_text) {
   if (!session_ || transcript_text.empty()) {
     return;
   }

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -489,6 +489,7 @@ void VinputEngine::enterPendingStartState(fcitx::InputContext* ic, const fcitx::
   if (status_ic_ && status_ic_ != ic) {
     clearVoicePresentation(status_ic_);
   }
+  const bool raw_prev = vinput::scene::Resolve(scene_config_, active_scene_id_).raw_prev;
   if (!session_) {
     session_.emplace(Session{Session::Phase::PendingStart,
                              ic,
@@ -496,7 +497,7 @@ void VinputEngine::enterPendingStartState(fcitx::InputContext* ic, const fcitx::
                              std::chrono::steady_clock::now(),
                              command_mode,
                              false,
-                             true,
+                             raw_prev,
                              {},
                              false});
   } else {
@@ -504,6 +505,7 @@ void VinputEngine::enterPendingStartState(fcitx::InputContext* ic, const fcitx::
     session_->ic = ic;
     session_->trigger = trigger;
     session_->command_mode = command_mode;
+    session_->raw_prev = raw_prev;
   }
   status_ic_ = ic;
   updateVoicePresentation(
@@ -523,6 +525,8 @@ void VinputEngine::enterRecordingState(fcitx::InputContext* ic, const fcitx::Key
   const bool stop_after_start =
       (trigger_mode_ == TriggerMode::Hold || (session_ && session_->stop_on_release)) && session_ &&
       session_->phase == Session::Phase::PendingStart && session_->trigger_released;
+  const bool raw_prev = session_ ? session_->raw_prev
+                                 : vinput::scene::Resolve(scene_config_, active_scene_id_).raw_prev;
   if (!session_) {
     session_.emplace(Session{Session::Phase::Recording,
                              ic,
@@ -530,7 +534,7 @@ void VinputEngine::enterRecordingState(fcitx::InputContext* ic, const fcitx::Key
                              std::chrono::steady_clock::now(),
                              command_mode,
                              false,
-                             true,
+                             raw_prev,
                              {},
                              false});
   } else {
@@ -538,6 +542,7 @@ void VinputEngine::enterRecordingState(fcitx::InputContext* ic, const fcitx::Key
     session_->ic = ic;
     session_->trigger = trigger;
     session_->command_mode = command_mode;
+    session_->raw_prev = raw_prev;
   }
   status_ic_ = ic;
   updateVoicePresentation(
@@ -552,7 +557,7 @@ void VinputEngine::enterRecordingState(fcitx::InputContext* ic, const fcitx::Key
 
 void VinputEngine::enterBusyState(fcitx::InputContext* ic, bool command_mode,
                                   const std::string& preedit_text, bool postprocessing,
-                                  bool raw_prev) {
+                                  std::optional<bool> raw_prev) {
   if (!ic) {
     return;
   }
@@ -560,16 +565,25 @@ void VinputEngine::enterBusyState(fcitx::InputContext* ic, bool command_mode,
   if (status_ic_ && status_ic_ != ic) {
     clearVoicePresentation(status_ic_);
   }
+  const bool effective_raw_prev = raw_prev.value_or(
+      session_ ? session_->raw_prev
+               : vinput::scene::Resolve(scene_config_, active_scene_id_).raw_prev);
   const auto phase = postprocessing ? Session::Phase::Postprocessing : Session::Phase::Inferring;
   if (!session_) {
-    session_.emplace(Session{
-        phase, ic, fcitx::Key(), std::chrono::steady_clock::now(), command_mode, {}, raw_prev, {}});
+    session_.emplace(Session{phase,
+                             ic,
+                             fcitx::Key(),
+                             std::chrono::steady_clock::now(),
+                             command_mode,
+                             {},
+                             effective_raw_prev,
+                             {}});
   } else {
     session_->phase = phase;
     session_->ic = ic;
     session_->trigger = fcitx::Key();
     session_->command_mode = command_mode;
-    session_->raw_prev = raw_prev;
+    session_->raw_prev = effective_raw_prev;
   }
   status_ic_ = ic;
   if (postprocessing && !session_->raw_prev) {
@@ -793,14 +807,19 @@ void VinputEngine::applyDaemonStatusLocally(const std::string& status,
   }
 
   if (status == kStatusInferring) {
+    const bool raw_prev = session_
+                              ? session_->raw_prev
+                              : vinput::scene::Resolve(scene_config_, active_scene_id_).raw_prev;
     enterBusyState(ic, session_ ? session_->command_mode : prefer_command_mode,
-                   InferringPreeditText());
+                   InferringPreeditText(), false, raw_prev);
     return;
   }
 
   if (status == kStatusPostprocessing) {
     const bool command_mode = session_ ? session_->command_mode : prefer_command_mode;
-    const bool raw_prev = session_ ? session_->raw_prev : true;
+    const bool raw_prev = session_
+                              ? session_->raw_prev
+                              : vinput::scene::Resolve(scene_config_, active_scene_id_).raw_prev;
     enterBusyState(ic, command_mode, PostprocessingPreeditText(command_mode, raw_prev), true,
                    raw_prev);
     return;

--- a/src/addon/dbus/vinput_dbus.cpp
+++ b/src/addon/dbus/vinput_dbus.cpp
@@ -586,7 +586,7 @@ void VinputEngine::enterBusyState(fcitx::InputContext* ic, bool command_mode,
     session_->raw_prev = effective_raw_prev;
   }
   status_ic_ = ic;
-  if (postprocessing && !session_->raw_prev) {
+  if (!session_->raw_prev) {
     updateVoicePresentation(ic, preedit_text);
   } else if (postprocessing && !session_->transcript_text.empty()) {
     const auto transcript =
@@ -933,6 +933,10 @@ void VinputEngine::onRecognitionPartial(fcitx::dbus::Message& msg) {
     enterBusyState(ic, session_->command_mode,
                    PostprocessingPreeditText(session_->command_mode, session_->raw_prev), true,
                    session_->raw_prev);
+    return;
+  }
+
+  if (session_->phase == Session::Phase::Inferring && !session_->raw_prev) {
     return;
   }
 

--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -549,6 +549,7 @@ void VinputEngine::finishStopRecording() {
   active_scene_id_ = scene.id;
   session_->raw_prev = scene.raw_prev;
   session_->trigger = fcitx::Key();
-  enterBusyState(session_->ic, session_->command_mode, _("... Recognizing ..."));
+  enterBusyState(session_->ic, session_->command_mode, _("... Recognizing ..."), false,
+                 scene.raw_prev);
   callStopRecording(scene.id);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,3 +52,35 @@ if(Fcitx5Core_VERSION VERSION_GREATER_EQUAL "5.1.9")
 endif()
 
 add_test(NAME modifier-key-tests COMMAND modifier-key-tests)
+
+add_executable(raw-prev-tests
+    raw_prev_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/addon/core/vinput.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/addon/dbus/vinput_dbus.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/addon/input/vinput_keyevent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/addon/menu/palette_command.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/addon/menu/vinput_menu.cpp
+)
+
+target_include_directories(raw-prev-tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/addon
+)
+
+target_link_libraries(raw-prev-tests PRIVATE
+    common
+    Fcitx5::Core
+    Fcitx5::Module::DBus
+    Fcitx5::Module::Clipboard
+    Fcitx5::Module::Notifications
+    ${SDBUS_LIBRARIES}
+)
+
+if(Fcitx5Core_VERSION VERSION_GREATER_EQUAL "5.1.12")
+    target_compile_definitions(raw-prev-tests PRIVATE VINPUT_FCITX5_CORE_HAVE_ADDON_FACTORY_V2)
+endif()
+if(Fcitx5Core_VERSION VERSION_GREATER_EQUAL "5.1.9")
+    target_compile_definitions(raw-prev-tests PRIVATE VINPUT_FCITX5_CORE_HAVE_SET_COMMENT)
+endif()
+
+add_test(NAME raw-prev-tests COMMAND raw-prev-tests)

--- a/tests/raw_prev_tests.cpp
+++ b/tests/raw_prev_tests.cpp
@@ -1,0 +1,136 @@
+#include <cstdlib>
+#include <fcitx-config/rawconfig.h>
+#include <fcitx-utils/key.h>
+#include <fcitx-utils/keysym.h>
+#include <fcitx-utils/keysymgen.h>
+#include <fcitx/event.h>
+#include <fcitx/inputcontext.h>
+#include <fcitx/inputcontextmanager.h>
+#include <fcitx/inputpanel.h>
+#include <fcitx/instance.h>
+#include <iostream>
+#include <optional>
+#include <string>
+
+#include "core/vinput.h"
+
+namespace {
+
+void expect(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+    std::exit(1);
+  }
+}
+
+class TestInputContext : public fcitx::InputContext {
+public:
+  explicit TestInputContext(fcitx::Instance& instance)
+      : fcitx::InputContext(instance.inputContextManager()) {
+    created();
+  }
+  TestInputContext(const TestInputContext&) = delete;
+  TestInputContext& operator=(const TestInputContext&) = delete;
+  TestInputContext(TestInputContext&&) = delete;
+  TestInputContext& operator=(TestInputContext&&) = delete;
+  ~TestInputContext() override { destroy(); }
+  [[nodiscard]] const char* frontend() const override { return "test"; }
+
+protected:
+  void commitStringImpl(const std::string&) override {}
+  void deleteSurroundingTextImpl(int, unsigned int) override {}
+  void forwardKeyImpl(const fcitx::ForwardKeyEvent&) override {}
+  void updatePreeditImpl() override {}
+};
+
+} // namespace
+
+class VinputTestAccessor {
+public:
+  static void enterRecordingState(VinputEngine& engine, fcitx::InputContext* ic) {
+    engine.enterRecordingState(ic, fcitx::Key(FcitxKey_Alt_R), false);
+  }
+  static void enterBusyState(VinputEngine& engine, fcitx::InputContext* ic,
+                             const std::string& preedit, bool postprocessing = false,
+                             std::optional<bool> raw_prev = std::nullopt) {
+    engine.enterBusyState(ic, false, preedit, postprocessing, raw_prev);
+  }
+  static bool getSessionRawPrev(const VinputEngine& engine) {
+    return engine.session_ ? engine.session_->raw_prev : false;
+  }
+  static void setSessionRawPrev(VinputEngine& engine, bool raw_prev) {
+    if (engine.session_) {
+      engine.session_->raw_prev = raw_prev;
+    }
+  }
+  static void setSessionTranscript(VinputEngine& engine, const std::string& text) {
+    if (engine.session_) {
+      engine.session_->transcript_text = text;
+    }
+  }
+  static void finishFrontendSession(VinputEngine& engine, fcitx::InputContext* ic) {
+    engine.finishFrontendSession(ic);
+  }
+};
+
+namespace {
+
+void testRawPrevDisabledPresentation(VinputEngine& engine, TestInputContext& ic) {
+  // 1. Enter recording state and configure session with raw_prev=false
+  VinputTestAccessor::enterRecordingState(engine, &ic);
+  VinputTestAccessor::setSessionRawPrev(engine, false);
+  VinputTestAccessor::setSessionTranscript(engine, "Raw speech transcript that should not preview");
+
+  // 2. Transition to Inferring state without explicit raw_prev argument
+  VinputTestAccessor::enterBusyState(engine, &ic, "... Recognizing ...", false);
+  expect(!VinputTestAccessor::getSessionRawPrev(engine),
+         "session raw_prev=false must not be clobbered during Inferring transition");
+  expect(ic.inputPanel().auxDown().toString().empty(),
+         "aux_down must remain empty during Inferring when raw_prev is false");
+  expect(ic.inputPanel().preedit().toString() == "... Recognizing ...",
+         "preedit must show recognizing status instead of transcript when raw_prev is false");
+
+  // 3. Transition to Postprocessing state
+  VinputTestAccessor::enterBusyState(engine, &ic, "... Postprocessing ...", true);
+  expect(!VinputTestAccessor::getSessionRawPrev(engine),
+         "session raw_prev=false must not be clobbered during Postprocessing transition");
+  expect(ic.inputPanel().auxDown().toString().empty(),
+         "aux_down must remain empty during Postprocessing when raw_prev is false");
+  expect(ic.inputPanel().preedit().toString() == "... Postprocessing ...",
+         "preedit must show compact postprocessing status when raw_prev is false");
+
+  VinputTestAccessor::finishFrontendSession(engine, &ic);
+}
+
+void testRawPrevEnabledPresentation(VinputEngine& engine, TestInputContext& ic) {
+  // 1. Enter recording state and configure session with raw_prev=true
+  VinputTestAccessor::enterRecordingState(engine, &ic);
+  VinputTestAccessor::setSessionRawPrev(engine, true);
+  VinputTestAccessor::setSessionTranscript(engine, "Raw speech transcript preview");
+
+  // 2. Transition to Postprocessing state with raw_prev=true
+  VinputTestAccessor::enterBusyState(engine, &ic, "... Postprocessing ...", true, true);
+  expect(VinputTestAccessor::getSessionRawPrev(engine), "session raw_prev=true must be preserved");
+  expect(ic.inputPanel().auxDown().toString() == "Raw speech transcript preview",
+         "aux_down must display transcript preview during Postprocessing when raw_prev is true");
+
+  VinputTestAccessor::finishFrontendSession(engine, &ic);
+}
+
+} // namespace
+
+int main() {
+  char arg0[] = "vinput-raw-prev-test";
+  char arg1[] = "--disable=all";
+  char* argv[] = {arg0, arg1, nullptr};
+
+  fcitx::Instance instance(2, argv);
+  TestInputContext ic(instance);
+  VinputEngine engine(&instance);
+
+  testRawPrevDisabledPresentation(engine, ic);
+  testRawPrevEnabledPresentation(engine, ic);
+
+  std::cout << "All raw_prev presentation tests passed!\n";
+  return 0;
+}

--- a/tests/raw_prev_tests.cpp
+++ b/tests/raw_prev_tests.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <fcitx-utils/key.h>
 #include <fcitx-utils/keysymgen.h>
+#include <fcitx/event.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputcontextmanager.h>
 #include <fcitx/inputpanel.h>

--- a/tests/raw_prev_tests.cpp
+++ b/tests/raw_prev_tests.cpp
@@ -68,6 +68,12 @@ public:
       engine.session_->transcript_text = text;
     }
   }
+  static std::string getSessionTranscript(const VinputEngine& engine) {
+    return engine.session_ ? engine.session_->transcript_text : std::string{};
+  }
+  static void handleRecognitionPartial(VinputEngine& engine, const std::string& text) {
+    engine.handleRecognitionPartial(text);
+  }
   static void finishFrontendSession(VinputEngine& engine, fcitx::InputContext* ic) {
     engine.finishFrontendSession(ic);
   }
@@ -90,7 +96,18 @@ void testRawPrevDisabledPresentation(VinputEngine& engine, TestInputContext& ic)
   expect(ic.inputPanel().preedit().toString() == "... Recognizing ...",
          "preedit must show recognizing status instead of transcript when raw_prev is false");
 
-  // 3. Transition to Postprocessing state
+  // 3. Receive partial transcript during Inferring when raw_prev is false
+  VinputTestAccessor::handleRecognitionPartial(engine,
+                                               "Late partial transcript after recording stopped");
+  expect(VinputTestAccessor::getSessionTranscript(engine) ==
+             "Late partial transcript after recording stopped",
+         "session transcript must be updated in memory");
+  expect(ic.inputPanel().auxDown().toString().empty(),
+         "aux_down must remain empty when partial arrives during Inferring with raw_prev=false");
+  expect(ic.inputPanel().preedit().toString() == "... Recognizing ...",
+         "preedit must remain in recognizing status instead of displaying late transcript");
+
+  // 4. Transition to Postprocessing state
   VinputTestAccessor::enterBusyState(engine, &ic, "... Postprocessing ...", true);
   expect(!VinputTestAccessor::getSessionRawPrev(engine),
          "session raw_prev=false must not be clobbered during Postprocessing transition");

--- a/tests/raw_prev_tests.cpp
+++ b/tests/raw_prev_tests.cpp
@@ -1,9 +1,6 @@
 #include <cstdlib>
-#include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/key.h>
-#include <fcitx-utils/keysym.h>
 #include <fcitx-utils/keysymgen.h>
-#include <fcitx/event.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputcontextmanager.h>
 #include <fcitx/inputpanel.h>


### PR DESCRIPTION
Closes #208

### Implementation Tasks
- [x] 1. Preserve session raw_prev setting across busy state transitions
- [x] 2. Suppress live raw transcript rendering in inferring phase when raw_prev is false
- [x] 3. Add regression tests for raw_prev retention and quality gate validation

*AI-assisted — Tool: pi; model: openai-codex/gpt-6-astra; version: 0.85.1.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修正录音、推理和后处理阶段对原始预览设置的处理，现会正确遵循会话或场景配置。
  * 关闭原始预览时，推理阶段仍会更新内部实时转录，但不会显示原始文本预览，输入面板保持识别状态。
  * 开启原始预览时，输入面板会继续显示转录预览。

* **测试**
  * 新增覆盖推理阶段原始预览关闭场景的自动化回归测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves the session’s `raw_prev` preference through recording, inference, and postprocessing transitions while suppressing raw transcript presentation when preview is disabled.
- Captures and propagates the effective scene preview preference across frontend state transitions.
- Continues storing recognition partials internally while withholding their presentation during inference when `raw_prev` is false.
- Adds regression coverage for enabled and disabled raw-preview behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/addon/core/vinput.h | Changes busy-state preview handling to accept an optional override and exposes selected internals to the regression-test accessor. |
| src/addon/dbus/vinput_dbus.cpp | Preserves the effective raw-preview preference across daemon state transitions and suppresses transcript rendering during inference when preview is disabled. |
| src/addon/input/vinput_keyevent.cpp | Propagates the resolved scene preview preference when recording transitions into inference. |
| tests/CMakeLists.txt | Registers a dedicated raw-preview regression-test executable using the established addon test linkage. |
| tests/raw_prev_tests.cpp | Covers raw-preview retention and presentation behavior during inference and postprocessing. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Pending start] -->|capture raw_prev| B[Recording]
    B -->|stop recording| C[Inferring]
    C -->|partial transcript| D{raw_prev enabled?}
    D -->|Yes| E[Render transcript preview]
    D -->|No| F[Keep recognizing status]
    C --> G[Postprocessing]
    G -->|raw_prev enabled| H[Show transcript in auxiliary text]
    G -->|raw_prev disabled| I[Show compact status only]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(tests): add missing fcitx event head..."](https://github.com/xifan2333/fcitx5-vinput/commit/62b57214b234e65b9c207f6101e1cb04a0fdc5af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61272435)</sub>

<!-- /greptile_comment -->