### PR TITLE
fix(addon): restore non-modifier hold behavior in Both mode

### DIFF
--- a/src/addon/input/vinput_keyevent.cpp
+++ b/src/addon/input/vinput_keyevent.cpp
@@ -416,6 +416,24 @@ void VinputEngine::handleKeyEvent(fcitx::Event& event) {
       return;
     }
 
+    // Both mode starts non-modifier recordings immediately. Classify the first
+    // release even if startup is pending, so its duration decides whether the
+    // recording should stop once the daemon is ready.
+    if (trigger_mode_ == TriggerMode::Both && session_ && !session_->trigger.isModifier() &&
+        !session_->trigger_released &&
+        (session_->phase == Session::Phase::PendingStart ||
+         session_->phase == Session::Phase::Recording) &&
+        isReleaseOfActiveTrigger(keyEvent.key())) {
+      const auto held = std::chrono::steady_clock::now() - session_->press_time;
+      session_->trigger_released = true;
+      session_->stop_on_release = held >= hold_activation_delay_;
+      if (session_->stop_on_release && session_->phase == Session::Phase::Recording) {
+        scheduleStopRecording();
+      }
+      keyEvent.filterAndAccept();
+      return;
+    }
+
     // 4.2 Ongoing recording release tracking for hold-to-talk
     if (session_ && session_->stop_on_release && !session_->trigger_released &&
         isReleaseOfActiveTrigger(keyEvent.key())) {


### PR DESCRIPTION
Holding F10 or another non-modifier shortcut starts recording in Both mode, but releasing it leaves recording active until the next press.

Classify the first release via HoldActivationDelay: short taps keep recording, while long holds schedule a stop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化 Both 触发模式下非修饰键的释放处理。
  - 根据按键按下时长判断是否在达到长按时长后停止录音。
  - 改进录音等待或进行中的按键释放事件处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62699512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge functionally, with a non-blocking architecture concern around extending custom key-gesture state handling.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22xifan2333%2Ffcitx5-vinput%22%20on%20the%20existing%20branch%20%22codex%2Fissue-206-both-release%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fissue-206-both-release%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Faddon%2Finput%2Fvinput_keyevent.cpp%3A422-434%0AThis%20branch%20adds%20another%20timing-%20and%20phase-dependent%20gesture%20transition%20under%20%60src%2Faddon%2F%60%2C%20extending%20the%20locally%20maintained%20key%20state%20machine%20prohibited%20by%20the%20repository's%20upstream-first%20Fcitx5%20architecture%20rule.%20Express%20this%20release%20classification%20through%20the%20applicable%20upstream%20event-handling%20pattern%20to%20avoid%20further%20lifecycle%20divergence.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=xifan2333%2Ffcitx5-vinput&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Custom gesture state expansion** <a href="https://github.com/xifan2333/fcitx5-vinput/pull/217#discussion_r3981825745">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/addon/input/vinput_keyevent.cpp:422-434
This branch adds another timing- and phase-dependent gesture transition under `src/addon/`, extending the locally maintained key state machine prohibited by the repository's upstream-first Fcitx5 architecture rule. Express this release classification through the applicable upstream event-handling pattern to avoid further lifecycle divergence.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Preserves short-tap toggle behavior by leaving recording active below `HoldActivationDelay`.
- Schedules recording shutdown for long holds immediately or after the pending start completes.
- Consumes the classified release consistently with the trigger press.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Non-modifier press in Both mode] --> B[Start recording]
    B --> C{Phase on first release}
    C -->|PendingStart| D[Classify elapsed hold]
    C -->|Recording| D
    D --> E{Held at least activation delay?}
    E -->|No| F[Keep recording]
    E -->|Yes, Recording| G[Schedule stop]
    E -->|Yes, PendingStart| H[Preserve stop flags]
    H --> I[Enter Recording state]
    I --> G
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(addon): restore non-modifier hold be..."](https://github.com/xifan2333/fcitx5-vinput/commit/e6a7899374c6ad3f12e204096d1127ef33bb235b)</sub>

<!-- /greptile_comment -->